### PR TITLE
[codex] Add Telegram Stars payment ledger schema

### DIFF
--- a/apps/spacetime/spacetimedb/src/index.ts
+++ b/apps/spacetime/spacetimedb/src/index.ts
@@ -98,6 +98,38 @@ const botMoveCommit = table(
   }
 );
 
+// Private: contains Telegram payment identifiers and must not be exposed to client subscriptions.
+const paymentLedger = table(
+  {
+    name: 'payment_ledger',
+    indexes: [
+      { accessor: 'payment_ledger_account_id', algorithm: 'btree', columns: ['accountId'] },
+      { accessor: 'payment_ledger_telegram_user_id', algorithm: 'btree', columns: ['telegramUserId'] },
+      { accessor: 'payment_ledger_charge_id', algorithm: 'btree', columns: ['telegramPaymentChargeId'] },
+      { accessor: 'payment_ledger_status', algorithm: 'btree', columns: ['status'] },
+    ],
+  },
+  {
+    paymentId: t.string().primaryKey(),
+    accountId: t.string(),
+    telegramUserId: t.string(),
+    starsAmount: t.u32(),
+    elmAmount: t.u32(),
+    refundedStarsAmount: t.u32().default(0),
+    refundedElmAmount: t.u32().default(0),
+    telegramPaymentChargeId: t.string().default(''),
+    invoicePayload: t.string(),
+    balanceKind: t.string().default('paid_elm'),
+    status: t.string(),
+    createdAtMicros: t.u64(),
+    paidAtMicros: t.u64().optional().default(undefined),
+    creditedAtMicros: t.u64().optional().default(undefined),
+    refundRequestedAtMicros: t.u64().optional().default(undefined),
+    refundedAtMicros: t.u64().optional().default(undefined),
+    updatedAtMicros: t.u64(),
+  }
+);
+
 const matchState = table(
   { name: 'match_state', public: true },
   {
@@ -191,6 +223,7 @@ const spacetimedb = schema({
   queueEntry,
   automationGuard,
   botMoveCommit,
+  paymentLedger,
   matchState,
   roundResult,
   gameEvent,

--- a/apps/tma/index.html
+++ b/apps/tma/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
     <meta name="theme-color" content="#0a0a1a" />
     <title>Elmental — Elemental Battle</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚔️</text></svg>" />

--- a/apps/tma/src/module_bindings/types.ts
+++ b/apps/tma/src/module_bindings/types.ts
@@ -91,6 +91,27 @@ export const MatchState = __t.object("MatchState", {
 });
 export type MatchState = __Infer<typeof MatchState>;
 
+export const PaymentLedger = __t.object("PaymentLedger", {
+  paymentId: __t.string(),
+  accountId: __t.string(),
+  telegramUserId: __t.string(),
+  starsAmount: __t.u32(),
+  elmAmount: __t.u32(),
+  refundedStarsAmount: __t.u32(),
+  refundedElmAmount: __t.u32(),
+  telegramPaymentChargeId: __t.string(),
+  invoicePayload: __t.string(),
+  balanceKind: __t.string(),
+  status: __t.string(),
+  createdAtMicros: __t.u64(),
+  paidAtMicros: __t.option(__t.u64()),
+  creditedAtMicros: __t.option(__t.u64()),
+  refundRequestedAtMicros: __t.option(__t.u64()),
+  refundedAtMicros: __t.option(__t.u64()),
+  updatedAtMicros: __t.u64(),
+});
+export type PaymentLedger = __Infer<typeof PaymentLedger>;
+
 export const Player = __t.object("Player", {
   identity: __t.identity(),
   name: __t.string(),


### PR DESCRIPTION
## What changed
- Added a private SpacetimeDB `payment_ledger` table for Telegram Stars purchase/refund accounting.
- Added indexes for account ID, Telegram user ID, Telegram charge ID, and status lookup.
- Regenerated SpacetimeDB TypeScript bindings so the private ledger type is available to backend-adjacent tooling without exposing the table to client subscriptions.

## Why
This is the foundation for Telegram Stars paid `ELM`: payment confirmation, idempotent crediting, refund-backed reverse conversion, and support traceability need an auditable server-side ledger before UI or payment-service work can be safe.

## Notes
The table is intentionally not public because it stores Telegram user IDs and payment charge IDs. Future wallet history should use a sanitized view/event stream rather than subscribing clients to this table directly.

## Validation
- `spacetime build --module-path apps/spacetime/spacetimedb`
- `pnpm stdb:generate`
- `pnpm --filter @elmental/tma build`

Closes #31
