### PR TITLE
[codex] Add Telegram Stars payment service

### DIFF
--- a/apps/payments/package.json
+++ b/apps/payments/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@elmental/payments",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "test": "vitest run"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "tsx": "^4.16.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/apps/payments/src/config.ts
+++ b/apps/payments/src/config.ts
@@ -2,6 +2,7 @@ export interface PaymentsConfig {
   port: number;
   botToken: string;
   payloadSecret: string;
+  webhookSecret?: string;
   botApiBaseUrl: string;
   allowedOrigins: string[];
   nodeEnv: string;
@@ -21,6 +22,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): PaymentsConfig
     port: parsePort(env['PAYMENTS_PORT'] ?? env['PORT'] ?? '3002'),
     botToken,
     payloadSecret,
+    ...(env['PAYMENTS_WEBHOOK_SECRET'] ? { webhookSecret: env['PAYMENTS_WEBHOOK_SECRET'] } : {}),
     botApiBaseUrl: env['TELEGRAM_BOT_API_BASE_URL'] ?? 'https://api.telegram.org',
     allowedOrigins: parseAllowedOrigins(env['PAYMENTS_ALLOWED_ORIGINS'] ?? '*'),
     nodeEnv,

--- a/apps/payments/src/config.ts
+++ b/apps/payments/src/config.ts
@@ -1,0 +1,40 @@
+export interface PaymentsConfig {
+  port: number;
+  botToken: string;
+  payloadSecret: string;
+  botApiBaseUrl: string;
+  allowedOrigins: string[];
+  nodeEnv: string;
+}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): PaymentsConfig {
+  const nodeEnv = env['NODE_ENV'] ?? 'development';
+  const isDevLike = nodeEnv === 'development' || nodeEnv === 'test';
+  const botToken = env['TELEGRAM_BOT_TOKEN'] ?? env['BOT_TOKEN'];
+  const payloadSecret = env['PAYMENT_PAYLOAD_SECRET'] ??
+    (isDevLike ? 'dev_payment_payload_secret_change_in_production' : undefined);
+
+  if (!botToken) throw new Error('Missing TELEGRAM_BOT_TOKEN');
+  if (!payloadSecret) throw new Error('Missing PAYMENT_PAYLOAD_SECRET');
+
+  return {
+    port: parsePort(env['PAYMENTS_PORT'] ?? env['PORT'] ?? '3002'),
+    botToken,
+    payloadSecret,
+    botApiBaseUrl: env['TELEGRAM_BOT_API_BASE_URL'] ?? 'https://api.telegram.org',
+    allowedOrigins: parseAllowedOrigins(env['PAYMENTS_ALLOWED_ORIGINS'] ?? '*'),
+    nodeEnv,
+  };
+}
+
+function parsePort(value: string): number {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port <= 0 || port > 65_535) {
+    throw new Error(`Invalid port: ${value}`);
+  }
+  return port;
+}
+
+function parseAllowedOrigins(value: string): string[] {
+  return value.split(',').map(origin => origin.trim()).filter(Boolean);
+}

--- a/apps/payments/src/index.ts
+++ b/apps/payments/src/index.ts
@@ -1,0 +1,21 @@
+import { loadConfig } from './config.js';
+import { createPaymentsServer } from './server.js';
+import { createTelegramBotApi } from './telegramBotApi.js';
+
+const config = loadConfig();
+const telegram = createTelegramBotApi(config.botToken, config.botApiBaseUrl);
+const server = createPaymentsServer({ config, telegram });
+
+server.listen(config.port, () => {
+  console.log(`[payments] Service listening on port ${config.port}`);
+});
+
+function shutdown(): void {
+  console.log('[payments] Shutting down...');
+  server.close(() => {
+    process.exit(0);
+  });
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/apps/payments/src/invoicePayload.test.ts
+++ b/apps/payments/src/invoicePayload.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { createSignedInvoicePayload, verifySignedInvoicePayload } from './invoicePayload.js';
+
+const secret = 'test_secret';
+
+describe('invoice payload signing', () => {
+  it('creates a compact Telegram-safe signed payload', () => {
+    const claims = {
+      purchaseId: '0123456789abcdef',
+      packageId: 'stars_5',
+      telegramUserId: '123456789',
+      accountId: 'telegram:123456789',
+    };
+
+    const payload = createSignedInvoicePayload(claims, secret);
+
+    expect(Buffer.byteLength(payload, 'utf8')).toBeLessThanOrEqual(128);
+    expect(verifySignedInvoicePayload(payload, secret)).toEqual(claims);
+  });
+
+  it('rejects tampered payloads', () => {
+    const payload = createSignedInvoicePayload(
+      {
+        purchaseId: '0123456789abcdef',
+        packageId: 'stars_1',
+        telegramUserId: '123456789',
+        accountId: 'telegram:123456789',
+      },
+      secret,
+    );
+
+    expect(verifySignedInvoicePayload(payload.replace('stars_1', 'stars_10'), secret)).toBeNull();
+  });
+});

--- a/apps/payments/src/invoicePayload.ts
+++ b/apps/payments/src/invoicePayload.ts
@@ -1,0 +1,78 @@
+import crypto from 'crypto';
+
+const PAYLOAD_PREFIX = 'eg1';
+const SEPARATOR = '|';
+const MAX_TELEGRAM_PAYLOAD_BYTES = 128;
+
+export interface InvoicePayloadClaims {
+  purchaseId: string;
+  packageId: string;
+  telegramUserId: string;
+  accountId: string;
+}
+
+export function createPurchaseId(): string {
+  return crypto.randomBytes(8).toString('hex');
+}
+
+export function createSignedInvoicePayload(claims: InvoicePayloadClaims, secret: string): string {
+  validateClaims(claims);
+  if (!secret) throw new Error('Payment payload secret is required');
+
+  const body = payloadBody(claims);
+  const signature = signPayloadBody(body, secret);
+  const payload = `${body}${SEPARATOR}${signature}`;
+  if (Buffer.byteLength(payload, 'utf8') > MAX_TELEGRAM_PAYLOAD_BYTES) {
+    throw new Error('Invoice payload exceeds Telegram 128 byte limit');
+  }
+  return payload;
+}
+
+export function verifySignedInvoicePayload(payload: string, secret: string): InvoicePayloadClaims | null {
+  if (!secret || Buffer.byteLength(payload, 'utf8') > MAX_TELEGRAM_PAYLOAD_BYTES) return null;
+  const parts = payload.split(SEPARATOR);
+  if (parts.length !== 6 || parts[0] !== PAYLOAD_PREFIX) return null;
+
+  const [prefix, purchaseId, packageId, telegramUserId, accountId, receivedSignature] = parts;
+  const body = [prefix, purchaseId, packageId, telegramUserId, accountId].join(SEPARATOR);
+  const expectedSignature = signPayloadBody(body, secret);
+  if (!timingSafeEqual(receivedSignature, expectedSignature)) return null;
+
+  const claims = { purchaseId, packageId, telegramUserId, accountId };
+  try {
+    validateClaims(claims);
+  } catch {
+    return null;
+  }
+  return claims;
+}
+
+function payloadBody(claims: InvoicePayloadClaims): string {
+  return [
+    PAYLOAD_PREFIX,
+    claims.purchaseId,
+    claims.packageId,
+    claims.telegramUserId,
+    claims.accountId,
+  ].join(SEPARATOR);
+}
+
+function signPayloadBody(body: string, secret: string): string {
+  return crypto.createHmac('sha256', secret).update(body).digest('base64url');
+}
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const aBuffer = Buffer.from(a);
+  const bBuffer = Buffer.from(b);
+  return aBuffer.length === bBuffer.length && crypto.timingSafeEqual(aBuffer, bBuffer);
+}
+
+function validateClaims(claims: InvoicePayloadClaims): void {
+  if (!/^[a-f0-9]{16}$/.test(claims.purchaseId)) throw new Error('Invalid purchase id');
+  if (!/^stars_(1|5|10)$/.test(claims.packageId)) throw new Error('Invalid package id');
+  if (!/^\d{1,20}$/.test(claims.telegramUserId)) throw new Error('Invalid Telegram user id');
+  if (claims.accountId !== `telegram:${claims.telegramUserId}`) throw new Error('Invalid account id');
+  if (Object.values(claims).some(value => value.includes(SEPARATOR))) {
+    throw new Error('Invoice payload fields cannot contain separator');
+  }
+}

--- a/apps/payments/src/packages.ts
+++ b/apps/payments/src/packages.ts
@@ -1,0 +1,37 @@
+export interface ElmStarsPackage {
+  id: string;
+  starsAmount: number;
+  elmAmount: number;
+  title: string;
+  description: string;
+}
+
+export const ELM_STARS_PACKAGES = [
+  {
+    id: 'stars_1',
+    starsAmount: 1,
+    elmAmount: 100,
+    title: '100 ELM',
+    description: '100 paid ELM for Elmental PvP',
+  },
+  {
+    id: 'stars_5',
+    starsAmount: 5,
+    elmAmount: 600,
+    title: '600 ELM',
+    description: '600 paid ELM for Elmental PvP',
+  },
+  {
+    id: 'stars_10',
+    starsAmount: 10,
+    elmAmount: 1300,
+    title: '1300 ELM',
+    description: '1300 paid ELM for Elmental PvP',
+  },
+] as const satisfies readonly ElmStarsPackage[];
+
+export type ElmStarsPackageId = (typeof ELM_STARS_PACKAGES)[number]['id'];
+
+export function findElmStarsPackage(packageId: string): ElmStarsPackage | undefined {
+  return ELM_STARS_PACKAGES.find(pkg => pkg.id === packageId);
+}

--- a/apps/payments/src/server.test.ts
+++ b/apps/payments/src/server.test.ts
@@ -2,8 +2,10 @@ import crypto from 'crypto';
 import type http from 'http';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { loadConfig } from './config.js';
+import { createSignedInvoicePayload } from './invoicePayload.js';
 import { createPaymentsServer } from './server.js';
 import type { TelegramBotApi } from './telegramBotApi.js';
+import type { PaymentEventRecorder } from './telegramUpdates.js';
 
 const botToken = '123456:test_bot_token';
 const config = loadConfig({
@@ -25,6 +27,7 @@ describe('payments server', () => {
   it('creates a Telegram Stars invoice for a valid Telegram user', async () => {
     const telegram: TelegramBotApi = {
       createInvoiceLink: vi.fn(async () => 'https://t.me/$invoice/test'),
+      answerPreCheckoutQuery: vi.fn(async () => undefined),
     };
     const baseUrl = await listen(telegram);
 
@@ -51,6 +54,7 @@ describe('payments server', () => {
   it('rejects browser/demo requests without Telegram init data', async () => {
     const telegram: TelegramBotApi = {
       createInvoiceLink: vi.fn(async () => 'unused'),
+      answerPreCheckoutQuery: vi.fn(async () => undefined),
     };
     const baseUrl = await listen(telegram);
 
@@ -63,14 +67,92 @@ describe('payments server', () => {
     expect(response.status).toBe(401);
     expect(telegram.createInvoiceLink).not.toHaveBeenCalled();
   });
+
+  it('accepts valid Telegram pre-checkout updates', async () => {
+    const telegram: TelegramBotApi = {
+      createInvoiceLink: vi.fn(async () => 'unused'),
+      answerPreCheckoutQuery: vi.fn(async () => undefined),
+    };
+    const baseUrl = await listen(telegram);
+    const payload = createPayload('stars_1', 99);
+
+    const response = await fetch(`${baseUrl}/telegram/webhook`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        pre_checkout_query: {
+          id: 'pcq_1',
+          from: { id: 99 },
+          currency: 'XTR',
+          total_amount: 1,
+          invoice_payload: payload,
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(telegram.answerPreCheckoutQuery).toHaveBeenCalledWith({
+      preCheckoutQueryId: 'pcq_1',
+      ok: true,
+    });
+  });
+
+  it('records valid successful payment updates', async () => {
+    const telegram: TelegramBotApi = {
+      createInvoiceLink: vi.fn(async () => 'unused'),
+      answerPreCheckoutQuery: vi.fn(async () => undefined),
+    };
+    const recorder: PaymentEventRecorder = {
+      recordSuccessfulPayment: vi.fn(async () => undefined),
+    };
+    const baseUrl = await listen(telegram, recorder);
+    const payload = createPayload('stars_10', 99);
+
+    const response = await fetch(`${baseUrl}/telegram/webhook`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        message: {
+          from: { id: 99 },
+          successful_payment: {
+            currency: 'XTR',
+            total_amount: 10,
+            invoice_payload: payload,
+            telegram_payment_charge_id: 'charge_123',
+          },
+        },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(recorder.recordSuccessfulPayment).toHaveBeenCalledWith(expect.objectContaining({
+      accountId: 'telegram:99',
+      packageId: 'stars_10',
+      starsAmount: 10,
+      elmAmount: 1300,
+      telegramPaymentChargeId: 'charge_123',
+    }));
+  });
 });
 
-async function listen(telegram: TelegramBotApi): Promise<string> {
-  server = createPaymentsServer({ config, telegram });
+async function listen(telegram: TelegramBotApi, paymentRecorder?: PaymentEventRecorder): Promise<string> {
+  server = createPaymentsServer({ config, telegram, paymentRecorder });
   await new Promise<void>(resolve => server?.listen(0, resolve));
   const address = server.address();
   if (!address || typeof address === 'string') throw new Error('Server did not listen on a TCP port');
   return `http://127.0.0.1:${address.port}`;
+}
+
+function createPayload(packageId: string, telegramUserId: number): string {
+  return createSignedInvoicePayload(
+    {
+      purchaseId: '0123456789abcdef',
+      packageId,
+      telegramUserId: String(telegramUserId),
+      accountId: `telegram:${telegramUserId}`,
+    },
+    config.payloadSecret,
+  );
 }
 
 function signedInitData(user: { id: number; first_name: string }): string {

--- a/apps/payments/src/server.test.ts
+++ b/apps/payments/src/server.test.ts
@@ -1,0 +1,87 @@
+import crypto from 'crypto';
+import type http from 'http';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { loadConfig } from './config.js';
+import { createPaymentsServer } from './server.js';
+import type { TelegramBotApi } from './telegramBotApi.js';
+
+const botToken = '123456:test_bot_token';
+const config = loadConfig({
+  NODE_ENV: 'test',
+  TELEGRAM_BOT_TOKEN: botToken,
+  PAYMENT_PAYLOAD_SECRET: 'test_payment_secret',
+  PAYMENTS_PORT: '3002',
+});
+
+let server: http.Server | null = null;
+
+afterEach(async () => {
+  if (!server) return;
+  await new Promise<void>(resolve => server?.close(() => resolve()));
+  server = null;
+});
+
+describe('payments server', () => {
+  it('creates a Telegram Stars invoice for a valid Telegram user', async () => {
+    const telegram: TelegramBotApi = {
+      createInvoiceLink: vi.fn(async () => 'https://t.me/$invoice/test'),
+    };
+    const baseUrl = await listen(telegram);
+
+    const response = await fetch(`${baseUrl}/payments/stars/invoice`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        initData: signedInitData({ id: 99, first_name: 'Buyer' }),
+        packageId: 'stars_10',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as Record<string, unknown>;
+    expect(body['accountId']).toBe('telegram:99');
+    expect(body['currency']).toBe('XTR');
+    expect(body['invoiceLink']).toBe('https://t.me/$invoice/test');
+    expect(telegram.createInvoiceLink).toHaveBeenCalledWith(expect.objectContaining({
+      starsAmount: 10,
+      elmAmount: 1300,
+    }));
+  });
+
+  it('rejects browser/demo requests without Telegram init data', async () => {
+    const telegram: TelegramBotApi = {
+      createInvoiceLink: vi.fn(async () => 'unused'),
+    };
+    const baseUrl = await listen(telegram);
+
+    const response = await fetch(`${baseUrl}/payments/stars/invoice`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ packageId: 'stars_1' }),
+    });
+
+    expect(response.status).toBe(401);
+    expect(telegram.createInvoiceLink).not.toHaveBeenCalled();
+  });
+});
+
+async function listen(telegram: TelegramBotApi): Promise<string> {
+  server = createPaymentsServer({ config, telegram });
+  await new Promise<void>(resolve => server?.listen(0, resolve));
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Server did not listen on a TCP port');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+function signedInitData(user: { id: number; first_name: string }): string {
+  const params = new URLSearchParams({
+    auth_date: String(Math.floor(Date.now() / 1000)),
+    user: JSON.stringify(user),
+  });
+  const entries = [...params.entries()].map(([key, value]) => `${key}=${value}`).sort();
+  const dataCheckString = entries.join('\n');
+  const secretKey = crypto.createHmac('sha256', 'WebAppData').update(botToken).digest();
+  const hash = crypto.createHmac('sha256', secretKey).update(dataCheckString).digest('hex');
+  params.set('hash', hash);
+  return params.toString();
+}

--- a/apps/payments/src/server.ts
+++ b/apps/payments/src/server.ts
@@ -1,0 +1,148 @@
+import http from 'http';
+import { createPurchaseId, createSignedInvoicePayload } from './invoicePayload.js';
+import { ELM_STARS_PACKAGES, findElmStarsPackage } from './packages.js';
+import { validateTelegramInitData } from './telegramInitData.js';
+import type { PaymentsConfig } from './config.js';
+import type { TelegramBotApi } from './telegramBotApi.js';
+
+interface ServerDeps {
+  config: PaymentsConfig;
+  telegram: TelegramBotApi;
+}
+
+interface InvoiceRequestBody {
+  initData?: unknown;
+  packageId?: unknown;
+}
+
+export function createPaymentsServer({ config, telegram }: ServerDeps): http.Server {
+  return http.createServer((req, res) => {
+    void handleRequest(req, res, config, telegram).catch(err => {
+      console.error('[payments] Request failed:', err);
+      sendJson(res, 500, { error: 'Internal server error' });
+    });
+  });
+}
+
+async function handleRequest(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  config: PaymentsConfig,
+  telegram: TelegramBotApi,
+): Promise<void> {
+  setCors(req, res, config);
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
+  const url = new URL(req.url ?? '/', 'http://payments.local');
+
+  if (req.method === 'GET' && url.pathname === '/health') {
+    sendJson(res, 200, { status: 'ok', service: 'payments', ts: Date.now() });
+    return;
+  }
+
+  if (req.method === 'GET' && url.pathname === '/payments/stars/packages') {
+    sendJson(res, 200, { packages: ELM_STARS_PACKAGES });
+    return;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/payments/stars/invoice') {
+    await handleCreateInvoice(req, res, config, telegram);
+    return;
+  }
+
+  sendJson(res, 404, { error: 'Not found' });
+}
+
+async function handleCreateInvoice(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  config: PaymentsConfig,
+  telegram: TelegramBotApi,
+): Promise<void> {
+  const body = await readJsonBody<InvoiceRequestBody>(req);
+  const initData = typeof body.initData === 'string' ? body.initData : '';
+  const packageId = typeof body.packageId === 'string' ? body.packageId : '';
+
+  const user = validateTelegramInitData(initData, config.botToken);
+  if (!user) {
+    sendJson(res, 401, { error: 'Invalid Telegram init data' });
+    return;
+  }
+
+  const selectedPackage = findElmStarsPackage(packageId);
+  if (!selectedPackage) {
+    sendJson(res, 400, { error: 'Unknown ELM package' });
+    return;
+  }
+
+  const telegramUserId = String(user.id);
+  const accountId = `telegram:${telegramUserId}`;
+  const purchaseId = createPurchaseId();
+  const payload = createSignedInvoicePayload(
+    {
+      purchaseId,
+      packageId: selectedPackage.id,
+      telegramUserId,
+      accountId,
+    },
+    config.payloadSecret,
+  );
+
+  const invoiceLink = await telegram.createInvoiceLink({
+    title: selectedPackage.title,
+    description: selectedPackage.description,
+    payload,
+    starsAmount: selectedPackage.starsAmount,
+    elmAmount: selectedPackage.elmAmount,
+  });
+
+  console.log(
+    `[payments] Created Stars invoice purchase=${purchaseId} account=${accountId} package=${selectedPackage.id}`,
+  );
+  sendJson(res, 200, {
+    purchaseId,
+    accountId,
+    currency: 'XTR',
+    invoiceLink,
+    package: selectedPackage,
+  });
+}
+
+function setCors(req: http.IncomingMessage, res: http.ServerResponse, config: PaymentsConfig): void {
+  const origin = req.headers.origin;
+  const allowAny = config.allowedOrigins.includes('*');
+  if (allowAny) {
+    res.setHeader('access-control-allow-origin', '*');
+  } else if (origin && config.allowedOrigins.includes(origin)) {
+    res.setHeader('access-control-allow-origin', origin);
+    res.setHeader('vary', 'Origin');
+  }
+  res.setHeader('access-control-allow-methods', 'GET,POST,OPTIONS');
+  res.setHeader('access-control-allow-headers', 'content-type');
+}
+
+async function readJsonBody<T>(req: http.IncomingMessage): Promise<T> {
+  const chunks: Buffer[] = [];
+  let totalBytes = 0;
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    totalBytes += buffer.byteLength;
+    if (totalBytes > 32_768) throw new Error('Request body too large');
+    chunks.push(buffer);
+  }
+
+  if (chunks.length === 0) return {} as T;
+
+  const rawBody = Buffer.concat(chunks).toString('utf8');
+  return JSON.parse(rawBody) as T;
+}
+
+function sendJson(res: http.ServerResponse, statusCode: number, body: unknown): void {
+  res.writeHead(statusCode, { 'content-type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(body));
+}

--- a/apps/payments/src/server.ts
+++ b/apps/payments/src/server.ts
@@ -2,12 +2,15 @@ import http from 'http';
 import { createPurchaseId, createSignedInvoicePayload } from './invoicePayload.js';
 import { ELM_STARS_PACKAGES, findElmStarsPackage } from './packages.js';
 import { validateTelegramInitData } from './telegramInitData.js';
+import { handleTelegramUpdate, noopPaymentEventRecorder } from './telegramUpdates.js';
 import type { PaymentsConfig } from './config.js';
 import type { TelegramBotApi } from './telegramBotApi.js';
+import type { PaymentEventRecorder } from './telegramUpdates.js';
 
 interface ServerDeps {
   config: PaymentsConfig;
   telegram: TelegramBotApi;
+  paymentRecorder?: PaymentEventRecorder;
 }
 
 interface InvoiceRequestBody {
@@ -15,9 +18,9 @@ interface InvoiceRequestBody {
   packageId?: unknown;
 }
 
-export function createPaymentsServer({ config, telegram }: ServerDeps): http.Server {
+export function createPaymentsServer({ config, telegram, paymentRecorder = noopPaymentEventRecorder }: ServerDeps): http.Server {
   return http.createServer((req, res) => {
-    void handleRequest(req, res, config, telegram).catch(err => {
+    void handleRequest(req, res, config, telegram, paymentRecorder).catch(err => {
       console.error('[payments] Request failed:', err);
       sendJson(res, 500, { error: 'Internal server error' });
     });
@@ -29,6 +32,7 @@ async function handleRequest(
   res: http.ServerResponse,
   config: PaymentsConfig,
   telegram: TelegramBotApi,
+  paymentRecorder: PaymentEventRecorder,
 ): Promise<void> {
   setCors(req, res, config);
 
@@ -55,7 +59,33 @@ async function handleRequest(
     return;
   }
 
+  if (req.method === 'POST' && url.pathname === '/telegram/webhook') {
+    await handleTelegramWebhook(req, res, config, telegram, paymentRecorder);
+    return;
+  }
+
   sendJson(res, 404, { error: 'Not found' });
+}
+
+async function handleTelegramWebhook(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  config: PaymentsConfig,
+  telegram: TelegramBotApi,
+  paymentRecorder: PaymentEventRecorder,
+): Promise<void> {
+  if (config.webhookSecret && req.headers['x-telegram-bot-api-secret-token'] !== config.webhookSecret) {
+    sendJson(res, 401, { error: 'Invalid webhook secret' });
+    return;
+  }
+
+  const update = await readJsonBody<unknown>(req);
+  const result = await handleTelegramUpdate(update, {
+    payloadSecret: config.payloadSecret,
+    telegram,
+    recorder: paymentRecorder,
+  });
+  sendJson(res, 200, { ok: true, result });
 }
 
 async function handleCreateInvoice(

--- a/apps/payments/src/telegramBotApi.ts
+++ b/apps/payments/src/telegramBotApi.ts
@@ -1,0 +1,53 @@
+export interface CreateInvoiceLinkInput {
+  title: string;
+  description: string;
+  payload: string;
+  starsAmount: number;
+  elmAmount: number;
+}
+
+export interface TelegramBotApi {
+  createInvoiceLink(input: CreateInvoiceLinkInput): Promise<string>;
+}
+
+interface BotApiResponse<T> {
+  ok: boolean;
+  result?: T;
+  description?: string;
+}
+
+export function createTelegramBotApi(
+  botToken: string,
+  botApiBaseUrl = 'https://api.telegram.org',
+  fetchImpl: typeof fetch = fetch,
+): TelegramBotApi {
+  const baseUrl = botApiBaseUrl.replace(/\/+$/, '');
+
+  return {
+    async createInvoiceLink(input: CreateInvoiceLinkInput): Promise<string> {
+      const response = await fetchImpl(`${baseUrl}/bot${botToken}/createInvoiceLink`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          title: input.title,
+          description: input.description,
+          payload: input.payload,
+          currency: 'XTR',
+          prices: [
+            {
+              label: `${input.elmAmount} ELM`,
+              amount: input.starsAmount,
+            },
+          ],
+        }),
+      });
+
+      const parsed = await response.json() as BotApiResponse<string>;
+      if (!response.ok || !parsed.ok || typeof parsed.result !== 'string') {
+        throw new Error(parsed.description || `Telegram Bot API failed with HTTP ${response.status}`);
+      }
+
+      return parsed.result;
+    },
+  };
+}

--- a/apps/payments/src/telegramBotApi.ts
+++ b/apps/payments/src/telegramBotApi.ts
@@ -8,6 +8,13 @@ export interface CreateInvoiceLinkInput {
 
 export interface TelegramBotApi {
   createInvoiceLink(input: CreateInvoiceLinkInput): Promise<string>;
+  answerPreCheckoutQuery(input: AnswerPreCheckoutQueryInput): Promise<void>;
+}
+
+export interface AnswerPreCheckoutQueryInput {
+  preCheckoutQueryId: string;
+  ok: boolean;
+  errorMessage?: string;
 }
 
 interface BotApiResponse<T> {
@@ -48,6 +55,23 @@ export function createTelegramBotApi(
       }
 
       return parsed.result;
+    },
+
+    async answerPreCheckoutQuery(input: AnswerPreCheckoutQueryInput): Promise<void> {
+      const response = await fetchImpl(`${baseUrl}/bot${botToken}/answerPreCheckoutQuery`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          pre_checkout_query_id: input.preCheckoutQueryId,
+          ok: input.ok,
+          ...(input.errorMessage ? { error_message: input.errorMessage } : {}),
+        }),
+      });
+
+      const parsed = await response.json() as BotApiResponse<boolean>;
+      if (!response.ok || !parsed.ok) {
+        throw new Error(parsed.description || `Telegram Bot API failed with HTTP ${response.status}`);
+      }
     },
   };
 }

--- a/apps/payments/src/telegramInitData.test.ts
+++ b/apps/payments/src/telegramInitData.test.ts
@@ -1,0 +1,40 @@
+import crypto from 'crypto';
+import { describe, expect, it } from 'vitest';
+import { validateTelegramInitData } from './telegramInitData.js';
+
+const botToken = '123456:test_bot_token';
+
+describe('Telegram init data validation', () => {
+  it('accepts valid Telegram WebApp init data', () => {
+    const initData = signedInitData({
+      auth_date: String(Math.floor(Date.now() / 1000)),
+      query_id: 'AAHdF6IQAAAAAN0XohDhrOrc',
+      user: JSON.stringify({ id: 42, first_name: 'Alice', username: 'alice' }),
+    });
+
+    expect(validateTelegramInitData(initData, botToken)).toMatchObject({
+      id: 42,
+      first_name: 'Alice',
+      username: 'alice',
+    });
+  });
+
+  it('rejects tampered init data', () => {
+    const initData = signedInitData({
+      auth_date: String(Math.floor(Date.now() / 1000)),
+      user: JSON.stringify({ id: 42, first_name: 'Alice' }),
+    });
+
+    expect(validateTelegramInitData(initData.replace('Alice', 'Mallory'), botToken)).toBeNull();
+  });
+});
+
+function signedInitData(fields: Record<string, string>): string {
+  const params = new URLSearchParams(fields);
+  const entries = [...params.entries()].map(([key, value]) => `${key}=${value}`).sort();
+  const dataCheckString = entries.join('\n');
+  const secretKey = crypto.createHmac('sha256', 'WebAppData').update(botToken).digest();
+  const hash = crypto.createHmac('sha256', secretKey).update(dataCheckString).digest('hex');
+  params.set('hash', hash);
+  return params.toString();
+}

--- a/apps/payments/src/telegramInitData.ts
+++ b/apps/payments/src/telegramInitData.ts
@@ -1,0 +1,60 @@
+import crypto from 'crypto';
+
+export interface TelegramUser {
+  id: number;
+  first_name: string;
+  last_name?: string;
+  username?: string;
+  language_code?: string;
+}
+
+export function validateTelegramInitData(
+  initData: string,
+  botToken: string,
+  maxAgeSeconds = 86_400,
+): TelegramUser | null {
+  try {
+    const params = new URLSearchParams(initData);
+    const receivedHash = params.get('hash');
+    if (!receivedHash) return null;
+
+    const entries: string[] = [];
+    for (const [key, value] of params.entries()) {
+      if (key !== 'hash') entries.push(`${key}=${value}`);
+    }
+    entries.sort();
+    const dataCheckString = entries.join('\n');
+
+    const secretKey = crypto.createHmac('sha256', 'WebAppData').update(botToken).digest();
+    const expectedHash = crypto.createHmac('sha256', secretKey).update(dataCheckString).digest('hex');
+    if (!timingSafeHexEqual(receivedHash, expectedHash)) return null;
+
+    const authDate = Number(params.get('auth_date'));
+    if (!Number.isFinite(authDate) || Date.now() / 1000 - authDate > maxAgeSeconds) return null;
+
+    const rawUser = params.get('user');
+    if (!rawUser) return null;
+    const parsed: unknown = JSON.parse(rawUser);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+
+    const user = parsed as Record<string, unknown>;
+    if (typeof user['id'] !== 'number' || typeof user['first_name'] !== 'string') return null;
+
+    return {
+      id: user['id'],
+      first_name: user['first_name'],
+      ...(typeof user['last_name'] === 'string' ? { last_name: user['last_name'] } : {}),
+      ...(typeof user['username'] === 'string' ? { username: user['username'] } : {}),
+      ...(typeof user['language_code'] === 'string' ? { language_code: user['language_code'] } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function timingSafeHexEqual(a: string, b: string): boolean {
+  if (!/^[a-f0-9]+$/i.test(a) || !/^[a-f0-9]+$/i.test(b)) return false;
+  const aBuffer = Buffer.from(a, 'hex');
+  const bBuffer = Buffer.from(b, 'hex');
+  return aBuffer.length === bBuffer.length && crypto.timingSafeEqual(aBuffer, bBuffer);
+}

--- a/apps/payments/src/telegramUpdates.ts
+++ b/apps/payments/src/telegramUpdates.ts
@@ -1,0 +1,157 @@
+import { verifySignedInvoicePayload } from './invoicePayload.js';
+import { findElmStarsPackage } from './packages.js';
+import type { TelegramBotApi } from './telegramBotApi.js';
+
+export interface SuccessfulStarsPaymentEvent {
+  purchaseId: string;
+  accountId: string;
+  telegramUserId: string;
+  packageId: string;
+  starsAmount: number;
+  elmAmount: number;
+  telegramPaymentChargeId: string;
+  invoicePayload: string;
+}
+
+export interface PaymentEventRecorder {
+  recordSuccessfulPayment(event: SuccessfulStarsPaymentEvent): Promise<void>;
+}
+
+export const noopPaymentEventRecorder: PaymentEventRecorder = {
+  async recordSuccessfulPayment(event: SuccessfulStarsPaymentEvent): Promise<void> {
+    console.log(
+      `[payments] Successful Stars payment received purchase=${event.purchaseId} account=${event.accountId} charge=${event.telegramPaymentChargeId}`,
+    );
+  },
+};
+
+interface TelegramUpdate {
+  update_id?: number;
+  pre_checkout_query?: TelegramPreCheckoutQuery;
+  message?: TelegramMessage;
+}
+
+interface TelegramPreCheckoutQuery {
+  id?: string;
+  from?: { id?: number };
+  currency?: string;
+  total_amount?: number;
+  invoice_payload?: string;
+}
+
+interface TelegramMessage {
+  from?: { id?: number };
+  successful_payment?: TelegramSuccessfulPayment;
+}
+
+interface TelegramSuccessfulPayment {
+  currency?: string;
+  total_amount?: number;
+  invoice_payload?: string;
+  telegram_payment_charge_id?: string;
+}
+
+interface HandleUpdateDeps {
+  payloadSecret: string;
+  telegram: TelegramBotApi;
+  recorder: PaymentEventRecorder;
+}
+
+export async function handleTelegramUpdate(update: unknown, deps: HandleUpdateDeps): Promise<string> {
+  const typedUpdate = update as TelegramUpdate;
+  if (typedUpdate.pre_checkout_query) {
+    return handlePreCheckoutQuery(typedUpdate.pre_checkout_query, deps);
+  }
+  if (typedUpdate.message?.successful_payment) {
+    return handleSuccessfulPayment(typedUpdate.message, typedUpdate.message.successful_payment, deps);
+  }
+  return 'ignored';
+}
+
+async function handlePreCheckoutQuery(query: TelegramPreCheckoutQuery, deps: HandleUpdateDeps): Promise<string> {
+  const queryId = typeof query.id === 'string' ? query.id : '';
+  if (!queryId) return 'invalid_pre_checkout_query';
+
+  const validation = validateStarsPayment({
+    payload: query.invoice_payload,
+    currency: query.currency,
+    totalAmount: query.total_amount,
+    telegramUserId: query.from?.id,
+    payloadSecret: deps.payloadSecret,
+  });
+
+  await deps.telegram.answerPreCheckoutQuery({
+    preCheckoutQueryId: queryId,
+    ok: validation.ok,
+    ...(validation.ok ? {} : { errorMessage: validation.error }),
+  });
+
+  return validation.ok ? 'pre_checkout_accepted' : 'pre_checkout_rejected';
+}
+
+async function handleSuccessfulPayment(
+  message: TelegramMessage,
+  payment: TelegramSuccessfulPayment,
+  deps: HandleUpdateDeps,
+): Promise<string> {
+  const invoicePayload = typeof payment.invoice_payload === 'string' ? payment.invoice_payload : '';
+  const validation = validateStarsPayment({
+    payload: invoicePayload,
+    currency: payment.currency,
+    totalAmount: payment.total_amount,
+    telegramUserId: message.from?.id,
+    payloadSecret: deps.payloadSecret,
+  });
+  if (!validation.ok) {
+    console.warn(`[payments] Ignoring invalid successful_payment update: ${validation.error}`);
+    return 'successful_payment_rejected';
+  }
+
+  const chargeId = payment.telegram_payment_charge_id;
+  if (!chargeId) {
+    console.warn('[payments] Ignoring successful_payment without telegram_payment_charge_id');
+    return 'successful_payment_rejected';
+  }
+
+  await deps.recorder.recordSuccessfulPayment({
+    purchaseId: validation.claims.purchaseId,
+    accountId: validation.claims.accountId,
+    telegramUserId: validation.claims.telegramUserId,
+    packageId: validation.package.id,
+    starsAmount: validation.package.starsAmount,
+    elmAmount: validation.package.elmAmount,
+    telegramPaymentChargeId: chargeId,
+    invoicePayload,
+  });
+
+  return 'successful_payment_recorded';
+}
+
+function validateStarsPayment(input: {
+  payload?: string;
+  currency?: string;
+  totalAmount?: number;
+  telegramUserId?: number;
+  payloadSecret: string;
+}): (
+  | { ok: true; claims: NonNullable<ReturnType<typeof verifySignedInvoicePayload>>; package: NonNullable<ReturnType<typeof findElmStarsPackage>> }
+  | { ok: false; error: string }
+) {
+  if (input.currency !== 'XTR') return { ok: false, error: 'Invalid payment currency' };
+  if (typeof input.payload !== 'string') return { ok: false, error: 'Missing invoice payload' };
+  if (typeof input.telegramUserId !== 'number') return { ok: false, error: 'Missing Telegram user' };
+
+  const claims = verifySignedInvoicePayload(input.payload, input.payloadSecret);
+  if (!claims) return { ok: false, error: 'Invalid invoice payload' };
+  if (claims.telegramUserId !== String(input.telegramUserId)) {
+    return { ok: false, error: 'Invoice belongs to another Telegram user' };
+  }
+
+  const selectedPackage = findElmStarsPackage(claims.packageId);
+  if (!selectedPackage) return { ok: false, error: 'Unknown ELM package' };
+  if (input.totalAmount !== selectedPackage.starsAmount) {
+    return { ok: false, error: 'Invalid Stars amount' };
+  }
+
+  return { ok: true, claims, package: selectedPackage };
+}

--- a/apps/payments/tsconfig.json
+++ b/apps/payments/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node", "vitest"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,21 @@ importers:
         specifier: ^1.60.0
         version: 1.60.0
 
+  apps/payments:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.37
+      tsx:
+        specifier: ^4.16.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.5.0
+        version: 5.6.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@20.19.37)
+
   apps/server:
     dependencies:
       '@elmental/shared':
@@ -2348,6 +2363,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vary@1.1.2:


### PR DESCRIPTION
## What changed
- Added a separate `@elmental/payments` workspace app for Telegram Stars payment HTTP endpoints.
- Added fixed ELM package catalog: 1 Star -> 100 ELM, 5 Stars -> 600 ELM, 10 Stars -> 1300 ELM.
- Added Telegram WebApp init data validation for authenticated invoice creation.
- Added compact signed invoice payloads with purchase ID, package ID, Telegram user ID, and account ID under Telegram's 128 byte payload limit.
- Added Bot API `createInvoiceLink` integration using `currency=XTR` and no provider token.
- Added `/telegram/webhook` handling for `pre_checkout_query` and `successful_payment` updates.
- Added pre-checkout validation for signed payload, Telegram user, `XTR`, and expected Stars amount.
- Added a `PaymentEventRecorder` boundary for the next SpacetimeDB crediting step.
- Added tests for init data validation, payload signing, invoice endpoint behavior, pre-checkout, and successful payment recording.

## Why
This creates the payment-service boundary required before wiring TMA wallet UI or server-authoritative ELM crediting. The service is intentionally separate from the legacy Socket.io multiplayer server.

## Notes
This PR does not credit ELM yet. That should happen in the next slice through a trusted server-to-SpacetimeDB path with idempotent charge handling, not via a client-callable reducer.

## Validation
- `pnpm install`
- `pnpm --filter @elmental/payments test`
- `pnpm --filter @elmental/payments build`

Closes #32
Refs #33
