### PR TITLE
[codex] TMA wallet opens Telegram Stars invoices

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -49,6 +49,7 @@ jobs:
           VITE_GAME_TRACE: 'true'
           VITE_SPACETIME_URI: https://maincloud.spacetimedb.com
           VITE_SPACETIME_DB: elmental-v2
+          VITE_PAYMENTS_URL: ${{ vars.VITE_PAYMENTS_URL }}
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5

--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ VITE_GAME_TRANSPORT=spacetime
 VITE_SPACETIME_URI=https://maincloud.spacetimedb.com
 VITE_SPACETIME_DB=elmental-v2
 VITE_BOT_FALLBACK_SECONDS=30
+VITE_PAYMENTS_URL=<Telegram Stars payment service URL>
 ```
 
 Run the public two-player first-to-3 smoke locally:

--- a/apps/tma/src/screens/HomeScreen.tsx
+++ b/apps/tma/src/screens/HomeScreen.tsx
@@ -5,6 +5,13 @@ import { GameMode } from '@elmental/shared';
 import { haptic } from '../services/telegram';
 import { startMatchmaking } from '../services/gameService';
 import { playerDisplayName } from '../services/playerProfile';
+import {
+  ELM_STARS_PACKAGES,
+  openTelegramStarsInvoice,
+  requestStarsInvoice,
+  type ElmStarsPackageId,
+  type TelegramInvoiceStatus,
+} from '../services/payments';
 import { SwordsIcon } from '../components/icons/SwordsIcon';
 import { SkullIcon } from '../components/icons/SkullIcon';
 import { VortexIcon } from '../components/icons/VortexIcon';
@@ -39,6 +46,14 @@ const GAME_MODES = [
   },
 ] as const;
 
+type TopUpStatus = 'idle' | 'loading' | TelegramInvoiceStatus;
+
+interface TopUpState {
+  status: TopUpStatus;
+  packageId?: ElmStarsPackageId;
+  message?: string;
+}
+
 export function HomeScreen() {
   const {
     telegramUser,
@@ -51,6 +66,7 @@ export function HomeScreen() {
     setBoostEnabled,
     setScreen,
   } = useGameStore();
+  const [topUpState, setTopUpState] = React.useState<TopUpState>({ status: 'idle' });
 
   const displayName = playerDisplayName(telegramUser);
 
@@ -61,6 +77,8 @@ export function HomeScreen() {
 
   const stakeRequired = 100 + (boostEnabled ? 10 : 0);
   const canAffordMatch = elmBalance >= stakeRequired;
+  const showStarsTopUp = telegramUser?.source === 'telegram' && Boolean(telegramUser.initData);
+  const pendingPackageId = topUpState.status === 'loading' ? topUpState.packageId : undefined;
 
   const handlePlay = () => {
     if (!canAffordMatch) {
@@ -69,6 +87,28 @@ export function HomeScreen() {
     }
     haptic.medium();
     void startMatchmaking();
+  };
+
+  const handleTopUp = async (packageId: ElmStarsPackageId) => {
+    const initData = telegramUser?.initData ?? '';
+    if (!initData) {
+      haptic.error();
+      setTopUpState({ status: 'failed', message: 'Telegram session unavailable.' });
+      return;
+    }
+
+    haptic.selection();
+    setTopUpState({ status: 'loading', packageId, message: 'Opening invoice...' });
+
+    try {
+      const invoice = await requestStarsInvoice({ initData, packageId });
+      const invoiceStatus = await openTelegramStarsInvoice(invoice.invoiceLink);
+      setTopUpState(topUpStateForInvoiceStatus(invoiceStatus));
+      notifyInvoiceStatus(invoiceStatus);
+    } catch {
+      haptic.error();
+      setTopUpState({ status: 'failed', message: 'Payment failed.' });
+    }
   };
 
   return (
@@ -173,6 +213,56 @@ export function HomeScreen() {
               <div className="text-xs text-text-secondary">Win Rate</div>
             </div>
           </div>
+
+          {showStarsTopUp ? (
+            <div className="mt-4 pt-4 border-t border-bg-border text-left">
+              <div className="flex items-center justify-between gap-3 mb-2">
+                <div className="text-xs text-text-secondary font-semibold tracking-widest uppercase">
+                  Top up
+                </div>
+                <div className="flex items-center gap-1 text-xs font-bold text-gold">
+                  <StarIcon size={12} />
+                  Stars
+                </div>
+              </div>
+              <div className="grid grid-cols-3 gap-2">
+                {ELM_STARS_PACKAGES.map((pkg) => {
+                  const isPending = pendingPackageId === pkg.id;
+                  const disabled = topUpState.status === 'loading';
+                  return (
+                    <motion.button
+                      key={pkg.id}
+                      data-nav
+                      className="min-h-[58px] rounded-xl border px-2 py-2 flex flex-col items-center justify-center gap-1 transition-colors disabled:opacity-60 disabled:cursor-wait"
+                      style={{
+                        borderColor: isPending ? '#ffd700' : 'rgba(255,255,255,0.1)',
+                        background: isPending ? 'rgba(255, 215, 0, 0.12)' : 'rgba(255,255,255,0.04)',
+                      }}
+                      disabled={disabled}
+                      whileTap={!disabled ? { scale: 0.96 } : undefined}
+                      onClick={() => void handleTopUp(pkg.id)}
+                    >
+                      <span className="flex items-center justify-center gap-1 text-sm font-black text-gold leading-none">
+                        <StarIcon size={13} />
+                        {pkg.starsAmount}
+                      </span>
+                      <span className="text-[11px] font-bold text-text-primary leading-tight">
+                        {pkg.elmAmount.toLocaleString()} ELM
+                      </span>
+                    </motion.button>
+                  );
+                })}
+              </div>
+              {topUpState.message ? (
+                <div
+                  role="status"
+                  className={`mt-3 text-xs font-semibold leading-tight ${topUpStatusClass(topUpState.status)}`}
+                >
+                  {topUpState.message}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
         </motion.div>
 
         {/* Game Mode selector */}
@@ -309,4 +399,46 @@ export function HomeScreen() {
       </div>
     </div>
   );
+}
+
+function topUpStateForInvoiceStatus(status: TelegramInvoiceStatus): TopUpState {
+  switch (status) {
+    case 'paid':
+      return { status, message: 'Paid. Waiting for server balance.' };
+    case 'cancelled':
+      return { status, message: 'Payment canceled.' };
+    case 'pending':
+      return { status, message: 'Payment pending.' };
+    case 'failed':
+      return { status, message: 'Payment failed.' };
+    case 'unknown':
+      return { status, message: 'Payment status unknown.' };
+  }
+}
+
+function notifyInvoiceStatus(status: TelegramInvoiceStatus): void {
+  if (status === 'paid') {
+    haptic.success();
+  } else if (status === 'failed' || status === 'unknown') {
+    haptic.error();
+  } else {
+    haptic.selection();
+  }
+}
+
+function topUpStatusClass(status: TopUpStatus): string {
+  switch (status) {
+    case 'paid':
+      return 'text-energy-high';
+    case 'failed':
+    case 'unknown':
+      return 'text-energy-low';
+    case 'pending':
+      return 'text-water-light';
+    case 'cancelled':
+      return 'text-text-muted';
+    case 'loading':
+    case 'idle':
+      return 'text-text-secondary';
+  }
 }

--- a/apps/tma/src/services/payments.test.ts
+++ b/apps/tma/src/services/payments.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  openTelegramStarsInvoice,
+  requestStarsInvoice,
+} from './payments';
+
+describe('TMA Stars payments', () => {
+  it('requests a Stars invoice from the configured payment service', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      purchaseId: 'purchase_1',
+      accountId: 'telegram:123',
+      currency: 'XTR',
+      invoiceLink: 'https://t.me/$invoice/test',
+      package: {
+        id: 'stars_5',
+        starsAmount: 5,
+        elmAmount: 600,
+      },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as unknown as typeof fetch;
+
+    const invoice = await requestStarsInvoice({
+      initData: 'signed-init-data',
+      packageId: 'stars_5',
+      paymentsUrl: 'https://payments.example.test/',
+      fetchImpl,
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith('https://payments.example.test/payments/stars/invoice', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        initData: 'signed-init-data',
+        packageId: 'stars_5',
+      }),
+    });
+    expect(invoice).toMatchObject({
+      purchaseId: 'purchase_1',
+      accountId: 'telegram:123',
+      currency: 'XTR',
+      invoiceLink: 'https://t.me/$invoice/test',
+      package: { id: 'stars_5', starsAmount: 5, elmAmount: 600 },
+    });
+  });
+
+  it('does not request invoices without a payment service URL', async () => {
+    await expect(requestStarsInvoice({
+      initData: 'signed-init-data',
+      packageId: 'stars_1',
+      paymentsUrl: '',
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+    })).rejects.toThrow('Payments service URL is not configured');
+  });
+
+  it('opens invoices through Telegram WebApp openInvoice', async () => {
+    const openInvoice = vi.fn((_url: string, cb?: (status: string) => void) => {
+      cb?.('paid');
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        Telegram: {
+          WebApp: {
+            initData: 'signed-init-data',
+            initDataUnsafe: {},
+            openInvoice,
+          },
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+
+    await expect(openTelegramStarsInvoice('https://t.me/$invoice/test')).resolves.toBe('paid');
+    expect(openInvoice).toHaveBeenCalledWith('https://t.me/$invoice/test', expect.any(Function));
+  });
+});

--- a/apps/tma/src/services/payments.ts
+++ b/apps/tma/src/services/payments.ts
@@ -1,0 +1,139 @@
+import { getTelegramWebApp } from './telegram';
+
+export const ELM_STARS_PACKAGES = [
+  { id: 'stars_1', starsAmount: 1, elmAmount: 100 },
+  { id: 'stars_5', starsAmount: 5, elmAmount: 600 },
+  { id: 'stars_10', starsAmount: 10, elmAmount: 1300 },
+] as const;
+
+export type ElmStarsPackage = (typeof ELM_STARS_PACKAGES)[number];
+export type ElmStarsPackageId = ElmStarsPackage['id'];
+
+export interface StarsInvoiceResponse {
+  purchaseId: string;
+  accountId: string;
+  currency: 'XTR';
+  invoiceLink: string;
+  package: ElmStarsPackage;
+}
+
+export type TelegramInvoiceStatus = 'paid' | 'cancelled' | 'failed' | 'pending' | 'unknown';
+
+interface RequestStarsInvoiceInput {
+  initData: string;
+  packageId: ElmStarsPackageId;
+  paymentsUrl?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export async function requestStarsInvoice(input: RequestStarsInvoiceInput): Promise<StarsInvoiceResponse> {
+  if (!input.initData) {
+    throw new Error('Telegram session is missing');
+  }
+
+  const selectedPackage = findElmStarsPackage(input.packageId);
+  if (!selectedPackage) {
+    throw new Error('Unknown ELM package');
+  }
+
+  const paymentsUrl = normalizePaymentsUrl(input.paymentsUrl ?? configuredPaymentsUrl());
+  if (!paymentsUrl) {
+    throw new Error('Payments service URL is not configured');
+  }
+
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const response = await fetchImpl(`${paymentsUrl}/payments/stars/invoice`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      initData: input.initData,
+      packageId: input.packageId,
+    }),
+  });
+
+  const body = await readJsonBody(response);
+  if (!response.ok) {
+    throw new Error(readApiError(body) ?? 'Invoice request failed');
+  }
+
+  return parseInvoiceResponse(body, selectedPackage);
+}
+
+export function openTelegramStarsInvoice(invoiceLink: string): Promise<TelegramInvoiceStatus> {
+  const twa = getTelegramWebApp();
+  const openInvoice = twa?.openInvoice;
+  if (!twa || !openInvoice) {
+    throw new Error('Telegram invoices are unavailable in this session');
+  }
+
+  return new Promise((resolve) => {
+    openInvoice.call(twa, invoiceLink, status => {
+      resolve(normalizeInvoiceStatus(status));
+    });
+  });
+}
+
+export function findElmStarsPackage(packageId: string): ElmStarsPackage | undefined {
+  return ELM_STARS_PACKAGES.find(pkg => pkg.id === packageId);
+}
+
+function configuredPaymentsUrl(): string {
+  return import.meta.env.VITE_PAYMENTS_URL ?? import.meta.env.VITE_PAYMENT_SERVICE_URL ?? '';
+}
+
+function normalizePaymentsUrl(value: string): string {
+  return value.trim().replace(/\/+$/, '');
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return null;
+  }
+}
+
+function readApiError(body: unknown): string | null {
+  if (!isRecord(body) || typeof body.error !== 'string') return null;
+  return body.error;
+}
+
+function parseInvoiceResponse(body: unknown, fallbackPackage: ElmStarsPackage): StarsInvoiceResponse {
+  if (!isRecord(body)) throw new Error('Invalid invoice response');
+  const invoiceLink = typeof body.invoiceLink === 'string' ? body.invoiceLink : '';
+  const purchaseId = typeof body.purchaseId === 'string' ? body.purchaseId : '';
+  const accountId = typeof body.accountId === 'string' ? body.accountId : '';
+  const currency = body.currency === 'XTR' ? body.currency : null;
+  const responsePackage = parsePackage(body.package) ?? fallbackPackage;
+
+  if (!invoiceLink || !purchaseId || !accountId || !currency) {
+    throw new Error('Invalid invoice response');
+  }
+
+  return {
+    purchaseId,
+    accountId,
+    currency,
+    invoiceLink,
+    package: responsePackage,
+  };
+}
+
+function parsePackage(value: unknown): ElmStarsPackage | null {
+  if (!isRecord(value)) return null;
+  const packageId = typeof value.id === 'string' ? value.id : '';
+  const knownPackage = findElmStarsPackage(packageId);
+  if (!knownPackage) return null;
+  return knownPackage;
+}
+
+function normalizeInvoiceStatus(status: string | undefined): TelegramInvoiceStatus {
+  if (status === 'paid' || status === 'cancelled' || status === 'failed' || status === 'pending') {
+    return status;
+  }
+  return 'unknown';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/apps/tma/src/services/telegram.ts
+++ b/apps/tma/src/services/telegram.ts
@@ -68,6 +68,7 @@ export interface TelegramWebApp {
   offEvent(eventType: string, cb: (event?: unknown) => void): void;
   sendData(data: string): void;
   openLink(url: string): void;
+  openInvoice?(url: string, cb?: (status: string) => void): void;
   openTelegramLink(url: string): void;
   showPopup(params: unknown, cb?: (button_id: string) => void): void;
   showAlert(message: string, cb?: () => void): void;


### PR DESCRIPTION
## Summary

- Add a TMA payments helper for Telegram Stars invoice-link requests and WebApp `openInvoice` handling.
- Add a Telegram-only HomeScreen top-up UI for 1, 5, and 10 Star ELM packages with loading, paid, canceled, pending, and failed states.
- Keep the frontend from locally crediting ELM; paid invoices wait for subscribed server balance updates.
- Wire `VITE_PAYMENTS_URL` into the GitHub Pages build environment.

## Validation

- `pnpm --filter @elmental/tma test -- run`
- `pnpm --filter @elmental/tma build`
- Playwright browser smoke: web/demo session hides top-up; Telegram-like runtime shows packages, calls `openInvoice`, displays paid status, and leaves balance unchanged until server state changes.

Closes #34.

Stacked on #43 and depends on the payment service from #42.
