### PR TITLE
[codex] Apply Telegram top offset only in fullscreen

### DIFF
--- a/apps/tma/src/services/telegram.test.ts
+++ b/apps/tma/src/services/telegram.test.ts
@@ -147,6 +147,68 @@ describe('web user profile helpers', () => {
     expect(offEvent).toHaveBeenCalledWith('contentSafeAreaChanged', expect.any(Function));
   });
 
+  it('does not add Telegram fullscreen chrome offset outside fullscreen mode', () => {
+    setMockWindow('');
+    const setProperty = vi.fn();
+    Object.defineProperty(globalThis, 'document', {
+      value: {
+        documentElement: {
+          style: { setProperty },
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    window.Telegram = {
+      WebApp: {
+        viewportStableHeight: 720,
+        viewportHeight: 700,
+        isFullscreen: false,
+        safeAreaInset: { top: 12 },
+        contentSafeAreaInset: { top: 0 },
+        onEvent: vi.fn(),
+        offEvent: vi.fn(),
+      } as never,
+    };
+
+    const cleanup = installTelegramViewportSync();
+
+    expect(setProperty).toHaveBeenCalledWith('--elmental-js-safe-top', '12px');
+
+    cleanup();
+  });
+
+  it('keeps the app below Telegram fullscreen chrome when safe area is too small', () => {
+    setMockWindow('');
+    const setProperty = vi.fn();
+    Object.defineProperty(globalThis, 'document', {
+      value: {
+        documentElement: {
+          style: { setProperty },
+        },
+      },
+      configurable: true,
+      writable: true,
+    });
+    window.Telegram = {
+      WebApp: {
+        viewportStableHeight: 720,
+        viewportHeight: 700,
+        isFullscreen: true,
+        safeAreaInset: { top: 12 },
+        contentSafeAreaInset: { top: 0 },
+        onEvent: vi.fn(),
+        offEvent: vi.fn(),
+      } as never,
+    };
+
+    const cleanup = installTelegramViewportSync();
+
+    expect(setProperty).toHaveBeenCalledWith('--elmental-js-safe-top', '59px');
+
+    cleanup();
+  });
+
   it('falls back to a generated player when stored data is invalid', () => {
     const { localStorage } = setMockWindow('');
     localStorage.setItem('elmental.webUser', '{bad json');

--- a/apps/tma/src/services/telegram.ts
+++ b/apps/tma/src/services/telegram.ts
@@ -86,6 +86,7 @@ export interface WebUserProfile {
 
 const WEB_USER_STORAGE_KEY = 'elmental.webUser';
 const LEGACY_WEB_USER_STORAGE_KEY = 'elmental.devUser';
+const TELEGRAM_FULLSCREEN_TOP_CHROME_SAFE_AREA = 59;
 
 declare global {
   interface Window {
@@ -139,7 +140,11 @@ export function installTelegramViewportSync(): () => void {
 
     const safe = twa.safeAreaInset ?? {};
     const contentSafe = twa.contentSafeAreaInset ?? {};
-    root.style.setProperty('--elmental-js-safe-top', `${Math.max(toInset(safe.top), toInset(contentSafe.top))}px`);
+    const fullscreenTopInset = twa.isFullscreen ? TELEGRAM_FULLSCREEN_TOP_CHROME_SAFE_AREA : 0;
+    root.style.setProperty(
+      '--elmental-js-safe-top',
+      `${Math.max(toInset(safe.top), toInset(contentSafe.top), fullscreenTopInset)}px`,
+    );
     root.style.setProperty('--elmental-js-safe-right', `${Math.max(toInset(safe.right), toInset(contentSafe.right))}px`);
     root.style.setProperty('--elmental-js-safe-bottom', `${Math.max(toInset(safe.bottom), toInset(contentSafe.bottom))}px`);
     root.style.setProperty('--elmental-js-safe-left', `${Math.max(toInset(safe.left), toInset(contentSafe.left))}px`);


### PR DESCRIPTION
## Summary

- Detect Telegram fullscreen mode via `WebApp.isFullscreen` before applying the extra top safe-area offset.
- Increase the forced fullscreen top offset from 56px to 59px.
- Add tests proving non-fullscreen keeps the reported safe area while fullscreen gets the 59px guard.

## Validation

- `pnpm --filter @elmental/tma test -- run src/services/telegram.test.ts`
- `pnpm --filter @elmental/tma build`
