### PR TITLE
[codex] Separate paid ELM from demo tELM

### DIFF
--- a/apps/payments/src/module_bindings/account_table.ts
+++ b/apps/payments/src/module_bindings/account_table.ts
@@ -17,4 +17,5 @@ export default __t.row({
   wins: __t.u32(),
   losses: __t.u32(),
   balance: __t.i32(),
+  balanceKind: __t.string().name("balance_kind"),
 });

--- a/apps/payments/src/module_bindings/match_state_table.ts
+++ b/apps/payments/src/module_bindings/match_state_table.ts
@@ -19,6 +19,7 @@ export default __t.row({
   p1Rating: __t.i32().name("p_1_rating"),
   p2Rating: __t.i32().name("p_2_rating"),
   stake: __t.u32(),
+  balanceKind: __t.string().name("balance_kind"),
   mode: __t.string(),
   room: __t.string(),
   phase: __t.string(),

--- a/apps/payments/src/module_bindings/player_table.ts
+++ b/apps/payments/src/module_bindings/player_table.ts
@@ -18,5 +18,6 @@ export default __t.row({
   wins: __t.u32(),
   losses: __t.u32(),
   balance: __t.i32(),
+  balanceKind: __t.string().name("balance_kind"),
   accountId: __t.string().name("account_id"),
 });

--- a/apps/payments/src/module_bindings/queue_entry_table.ts
+++ b/apps/payments/src/module_bindings/queue_entry_table.ts
@@ -21,4 +21,5 @@ export default __t.row({
   joinedAtMicros: __t.u64().name("joined_at_micros"),
   botFallbackAtMicros: __t.option(__t.u64()).name("bot_fallback_at_micros"),
   accountId: __t.string().name("account_id"),
+  balanceKind: __t.string().name("balance_kind"),
 });

--- a/apps/payments/src/module_bindings/types.ts
+++ b/apps/payments/src/module_bindings/types.ts
@@ -17,6 +17,7 @@ export const Account = __t.object("Account", {
   wins: __t.u32(),
   losses: __t.u32(),
   balance: __t.i32(),
+  balanceKind: __t.string(),
 });
 export type Account = __Infer<typeof Account>;
 
@@ -65,6 +66,7 @@ export const MatchState = __t.object("MatchState", {
   p1Rating: __t.i32(),
   p2Rating: __t.i32(),
   stake: __t.u32(),
+  balanceKind: __t.string(),
   mode: __t.string(),
   room: __t.string(),
   phase: __t.string(),
@@ -120,6 +122,7 @@ export const Player = __t.object("Player", {
   wins: __t.u32(),
   losses: __t.u32(),
   balance: __t.i32(),
+  balanceKind: __t.string(),
   accountId: __t.string(),
 });
 export type Player = __Infer<typeof Player>;
@@ -135,6 +138,7 @@ export const QueueEntry = __t.object("QueueEntry", {
   joinedAtMicros: __t.u64(),
   botFallbackAtMicros: __t.option(__t.u64()),
   accountId: __t.string(),
+  balanceKind: __t.string(),
 });
 export type QueueEntry = __Infer<typeof QueueEntry>;
 

--- a/apps/spacetime/spacetimedb/src/index.ts
+++ b/apps/spacetime/spacetimedb/src/index.ts
@@ -26,16 +26,18 @@ const NEXT_ROUND_JITTER_MAX_MICROS = 500_000;
 const BOT_FALLBACK_DEFAULT_SECONDS = 30;
 const BOT_FALLBACK_MAX_SECONDS = 120;
 const BOT_NAME = 'AI Practice Bot';
-const BOT_IDENTITY = new Identity('b000000000000000000000000000000000000000000000000000000000000001');
+const DEMO_BOT_IDENTITY = new Identity('b000000000000000000000000000000000000000000000000000000000000001');
+const PAID_BOT_IDENTITY = new Identity('b000000000000000000000000000000000000000000000000000000000000002');
 const INITIAL_BALANCE = 1000;
 const BOT_BALANCE = 1_000_000;
 const RAKE_PERCENT = 5;
 const BOOST_STAKE_PERCENT = 10;
-const BOT_ACCOUNT_ID = 'bot:practice';
+const BOT_ACCOUNT_PREFIX = 'bot:practice';
 const PAYMENT_JWT_ISSUER = 'elmental-payments';
 const PAYMENT_JWT_AUDIENCE = 'elmental-v2-payments';
 const PAYMENT_JWT_SUBJECT = 'payments-service';
 const PAID_ELM_BALANCE_KIND = 'paid_elm';
+const DEMO_TELM_BALANCE_KIND = 'demo_teml';
 const PAYMENT_STATUS_CREDITED = 'credited';
 const ALL_MOVES = [0, 1, 2, 3, 4, 5] as const;
 const ELM_STARS_PACKAGES = [
@@ -53,6 +55,7 @@ const account = table(
     wins: t.u32(),
     losses: t.u32(),
     balance: t.i32().default(INITIAL_BALANCE),
+    balanceKind: t.string().default('demo_teml'),
   }
 );
 
@@ -66,6 +69,7 @@ const player = table(
     wins: t.u32(),
     losses: t.u32(),
     balance: t.i32().default(INITIAL_BALANCE),
+    balanceKind: t.string().default('demo_teml'),
     accountId: t.string().default(''),
   }
 );
@@ -83,6 +87,7 @@ const queueEntry = table(
     joinedAtMicros: t.u64(),
     botFallbackAtMicros: t.u64().optional().default(undefined),
     accountId: t.string().default(''),
+    balanceKind: t.string().default('demo_teml'),
   }
 );
 
@@ -151,6 +156,7 @@ const matchState = table(
     p1Rating: t.i32(),
     p2Rating: t.i32(),
     stake: t.u32(),
+    balanceKind: t.string().default('demo_teml'),
     mode: t.string(),
     room: t.string(),
     phase: t.string(),
@@ -277,6 +283,7 @@ export const onConnect = spacetimedb.clientConnected(ctx => {
     wins: accountRow.wins,
     losses: accountRow.losses,
     balance: accountRow.balance,
+    balanceKind: accountBalanceKind(accountRow),
   });
   logEvent(ctx, 'player.connected', undefined, `Player connected ${shortIdentity(ctx.sender)}`, identityHex(ctx.sender));
 });
@@ -359,6 +366,7 @@ export const join_queue = spacetimedb.reducer(
       boostEnabled,
       joinedAtMicros: now,
       botFallbackAtMicros: botFallbackDeadline(now, botFallbackSeconds),
+      balanceKind: accountBalanceKind(accountRow),
     };
 
     const opponent = findOpponentForEntry(ctx, currentEntry, now);
@@ -969,6 +977,7 @@ function createPlayerMatch(ctx: ReducerContext, p1Entry: QueueEntryRow, p2Entry:
   const p1Player = ctx.db.player.identity.find(p1Entry.identity);
   const p2Player = ctx.db.player.identity.find(p2Entry.identity);
   if (!p1Player || !p2Player) throw new SenderError('Player not found');
+  const balanceKind = assertSameEntryBalanceKind(p1Entry, p2Entry);
   const p1Account = reserveStake(ctx, p1Player, totalStake(p1Entry.stake, p1Entry.boostEnabled));
   const p2Account = reserveStake(ctx, p2Player, totalStake(p2Entry.stake, p2Entry.boostEnabled));
   const inserted = ctx.db.matchState.insert({
@@ -980,6 +989,7 @@ function createPlayerMatch(ctx: ReducerContext, p1Entry: QueueEntryRow, p2Entry:
     p1Rating: p1Account.rating,
     p2Rating: p2Account.rating,
     stake: p1Entry.stake,
+    balanceKind,
     mode: p1Entry.mode,
     room: p1Entry.room,
     phase: 'select',
@@ -1009,13 +1019,14 @@ function createPlayerMatch(ctx: ReducerContext, p1Entry: QueueEntryRow, p2Entry:
     'match.created',
     inserted,
     `Match ${inserted.id} created: ${p1Entry.name} vs ${p2Entry.name}`,
-    `room=${p1Entry.room} mode=${p1Entry.mode} stake=${p1Entry.stake}`
+    `room=${p1Entry.room} mode=${p1Entry.mode} stake=${p1Entry.stake} balanceKind=${balanceKind}`
   );
   return inserted;
 }
 
 function createBotMatch(ctx: ReducerContext, entry: QueueEntryRow, now: bigint) {
-  const botPlayer = ensureBotPlayer(ctx);
+  const balanceKind = entryBalanceKind(entry);
+  const botPlayer = ensureBotPlayer(ctx, balanceKind);
   const humanPlayer = ctx.db.player.identity.find(entry.identity);
   if (!humanPlayer) throw new SenderError('Player not found');
   const humanAccount = reserveStake(ctx, humanPlayer, totalStake(entry.stake, entry.boostEnabled));
@@ -1023,12 +1034,13 @@ function createBotMatch(ctx: ReducerContext, entry: QueueEntryRow, now: bigint) 
   const inserted = ctx.db.matchState.insert({
     id: 0n,
     p1: entry.identity,
-    p2: BOT_IDENTITY,
+    p2: botPlayer.identity,
     p1Name: entry.name,
     p2Name: botPlayer.name,
     p1Rating: humanAccount.rating,
     p2Rating: botAccount.rating,
     stake: entry.stake,
+    balanceKind,
     mode: entry.mode,
     room: entry.room,
     phase: 'select',
@@ -1060,13 +1072,14 @@ function createBotMatch(ctx: ReducerContext, entry: QueueEntryRow, now: bigint) 
     'bot.match_created',
     committed,
     `Bot fallback match ${committed.id} created for ${entry.name}`,
-    `room=${entry.room} mode=${entry.mode} stake=${entry.stake}`
+    `room=${entry.room} mode=${entry.mode} stake=${entry.stake} balanceKind=${balanceKind}`
   );
   return committed;
 }
 
-function ensureBotPlayer(ctx: ReducerContext) {
-  const botAccount = ensureAccount(ctx, BOT_ACCOUNT_ID, BOT_NAME, {
+function ensureBotPlayer(ctx: ReducerContext, balanceKind = DEMO_TELM_BALANCE_KIND) {
+  const botIdentity = botIdentityForBalanceKind(balanceKind);
+  const botAccount = ensureAccount(ctx, botAccountIdForBalanceKind(balanceKind), BOT_NAME, {
     rating: INITIAL_RATING,
     wins: 0,
     losses: 0,
@@ -1075,7 +1088,7 @@ function ensureBotPlayer(ctx: ReducerContext) {
   const fundedBotAccount = accountBalance(botAccount) < BOT_BALANCE
     ? updateAccount(ctx, { ...botAccount, balance: BOT_BALANCE })
     : botAccount;
-  const existing = ctx.db.player.identity.find(BOT_IDENTITY);
+  const existing = ctx.db.player.identity.find(botIdentity);
   if (existing) {
     const updated = playerFromAccount(existing, fundedBotAccount, BOT_NAME, true);
     ctx.db.player.identity.update(updated);
@@ -1083,7 +1096,7 @@ function ensureBotPlayer(ctx: ReducerContext) {
   }
 
   return ctx.db.player.insert({
-    identity: BOT_IDENTITY,
+    identity: botIdentity,
     accountId: fundedBotAccount.id,
     name: fundedBotAccount.name,
     online: true,
@@ -1091,6 +1104,7 @@ function ensureBotPlayer(ctx: ReducerContext) {
     wins: fundedBotAccount.wins,
     losses: fundedBotAccount.losses,
     balance: fundedBotAccount.balance,
+    balanceKind: accountBalanceKind(fundedBotAccount),
   });
 }
 
@@ -1134,7 +1148,7 @@ function isBotMatch(match: MatchRow) {
 }
 
 function isBotIdentity(identity: IdentityLike) {
-  return identityEquals(identity, BOT_IDENTITY);
+  return identityEquals(identity, DEMO_BOT_IDENTITY) || identityEquals(identity, PAID_BOT_IDENTITY);
 }
 
 function ensureBotCommitIfNeeded(ctx: ReducerContext, match: MatchRow, now: bigint) {
@@ -1220,7 +1234,14 @@ function botFallbackDeadline(now: bigint, requestedSeconds?: number) {
   return now + BigInt(clamped) * 1_000_000n;
 }
 
-function findOpponent(ctx: ReducerContext, stake: number, mode: string, room: string, now: bigint) {
+function findOpponent(
+  ctx: ReducerContext,
+  stake: number,
+  mode: string,
+  room: string,
+  now: bigint,
+  balanceKind = DEMO_TELM_BALANCE_KIND
+) {
   let candidate: MatchRow | undefined = undefined;
   for (const entry of ctx.db.queueEntry.iter()) {
     if (identityEquals(entry.identity, ctx.sender)) continue;
@@ -1249,6 +1270,7 @@ function findOpponent(ctx: ReducerContext, stake: number, mode: string, room: st
     }
     if (entry.room !== room) continue;
     if (entry.stake !== stake || entry.mode !== mode) continue;
+    if (entryBalanceKind(entry) !== balanceKind) continue;
     if (!candidate || entry.joinedAtMicros < candidate.joinedAtMicros) candidate = entry;
   }
   return candidate;
@@ -1284,6 +1306,7 @@ function findOpponentForEntry(ctx: ReducerContext, target: QueueEntryRow, now: b
     }
     if (entry.room !== target.room) continue;
     if (entry.stake !== target.stake || entry.mode !== target.mode) continue;
+    if (entryBalanceKind(entry) !== entryBalanceKind(target)) continue;
     if (!candidate || entry.joinedAtMicros < candidate.joinedAtMicros) candidate = entry;
   }
   return candidate;
@@ -1291,6 +1314,10 @@ function findOpponentForEntry(ctx: ReducerContext, target: QueueEntryRow, now: b
 
 function entryAccountId(entry: QueueEntryRow) {
   return normalizeAccountId(entry.accountId, defaultAccountId(entry.identity));
+}
+
+function entryBalanceKind(entry: QueueEntryRow) {
+  return normalizeBalanceKind(entry.balanceKind, balanceKindForAccountId(entryAccountId(entry)));
 }
 
 function findLatestActiveMatchForAccount(ctx: ReducerContext, accountId: string) {
@@ -1323,9 +1350,9 @@ function requirePlayer(ctx: ReducerContext) {
 function linkPlayerAccount(ctx: ReducerContext, playerRow: MatchRow, requestedAccountId: string | undefined, name: string) {
   const previousAccountId = playerAccountId(playerRow);
   const accountId = normalizeAccountId(requestedAccountId, previousAccountId);
-  const existingAccount = ctx.db.account.id.find(accountId);
-  const accountRow = existingAccount ?? ensureAccount(ctx, accountId, name, playerRow);
-  const namedAccount = previousAccountId !== accountId && existingAccount && hasLegacyProgress(playerRow)
+  const accountRow = ensureAccount(ctx, accountId, name, playerRow);
+  const previousBalanceKind = balanceKindForAccountId(previousAccountId);
+  const namedAccount = previousAccountId !== accountId && previousBalanceKind === accountBalanceKind(accountRow) && hasLegacyProgress(playerRow)
     ? mergeLegacyPlayerIntoAccount(ctx, accountRow, playerRow, name)
     : accountRow.name === name ? accountRow : updateAccount(ctx, { ...accountRow, name });
   ctx.db.player.identity.update(playerFromAccount(playerRow, namedAccount, name, true));
@@ -1334,8 +1361,17 @@ function linkPlayerAccount(ctx: ReducerContext, playerRow: MatchRow, requestedAc
 
 function ensureAccount(ctx: ReducerContext, accountId: string, name: string, seed?: Partial<AccountRow>) {
   const normalizedId = normalizeAccountId(accountId, undefined);
+  const balanceKind = balanceKindForAccountId(normalizedId);
   const existing = ctx.db.account.id.find(normalizedId);
-  if (existing) return existing;
+  if (existing) {
+    return accountBalanceKind(existing) === balanceKind
+      ? existing
+      : updateAccount(ctx, {
+          ...existing,
+          balance: migratedBalanceForBalanceKind(ctx, normalizedId, balanceKind),
+          balanceKind,
+        });
+  }
 
   return ctx.db.account.insert({
     id: normalizedId,
@@ -1343,14 +1379,21 @@ function ensureAccount(ctx: ReducerContext, accountId: string, name: string, see
     rating: seed?.rating ?? INITIAL_RATING,
     wins: seed?.wins ?? 0,
     losses: seed?.losses ?? 0,
-    balance: seed?.balance ?? INITIAL_BALANCE,
+    balance: seed?.balance ?? initialBalanceForBalanceKind(balanceKind),
+    balanceKind,
   });
 }
 
 function updateAccount(ctx: ReducerContext, accountRow: AccountRow) {
-  ctx.db.account.id.update(accountRow);
-  syncAccountToPlayers(ctx, accountRow);
-  return accountRow;
+  const normalizedId = normalizeAccountId(accountRow.id, undefined);
+  const normalized = {
+    ...accountRow,
+    id: normalizedId,
+    balanceKind: balanceKindForAccountId(normalizedId),
+  };
+  ctx.db.account.id.update(normalized);
+  syncAccountToPlayers(ctx, normalized);
+  return normalized;
 }
 
 function mergeLegacyPlayerIntoAccount(ctx: ReducerContext, accountRow: AccountRow, playerRow: MatchRow, name: string) {
@@ -1361,6 +1404,7 @@ function mergeLegacyPlayerIntoAccount(ctx: ReducerContext, accountRow: AccountRo
     wins: accountRow.wins + (playerRow.wins ?? 0),
     losses: accountRow.losses + (playerRow.losses ?? 0),
     balance: Math.max(accountBalance(accountRow), playerRow.balance ?? INITIAL_BALANCE),
+    balanceKind: accountBalanceKind(accountRow),
   });
 }
 
@@ -1390,6 +1434,7 @@ function playerFromAccount(playerRow: MatchRow, accountRow: AccountRow, name = a
     wins: accountRow.wins,
     losses: accountRow.losses,
     balance: accountBalance(accountRow),
+    balanceKind: accountBalanceKind(accountRow),
   };
 }
 
@@ -1422,7 +1467,7 @@ function reserveStake(ctx: ReducerContext, playerRow: MatchRow, amount: number) 
 
 function assertCanStakeAccount(accountRow: AccountRow, amount: number) {
   if (accountBalance(accountRow) < amount) {
-    throw new SenderError(`Insufficient ELM balance: need ${amount}, have ${accountBalance(accountRow)}`);
+    throw new SenderError(`Insufficient ${currencyLabelForBalanceKind(accountBalanceKind(accountRow))} balance: need ${amount}, have ${accountBalance(accountRow)}`);
   }
 }
 
@@ -1559,6 +1604,59 @@ function calculateWinnerPayout(stake: number) {
 
 function accountBalance(accountRow: AccountRow) {
   return accountRow.balance ?? INITIAL_BALANCE;
+}
+
+function accountBalanceKind(accountRow: AccountRow) {
+  return normalizeBalanceKind(accountRow.balanceKind, balanceKindForAccountId(accountRow.id));
+}
+
+function balanceKindForAccountId(accountId: string) {
+  const normalized = normalizeAccountId(accountId, undefined);
+  if (normalized.startsWith('telegram:')) return PAID_ELM_BALANCE_KIND;
+  if (normalized === botAccountIdForBalanceKind(PAID_ELM_BALANCE_KIND)) return PAID_ELM_BALANCE_KIND;
+  return DEMO_TELM_BALANCE_KIND;
+}
+
+function normalizeBalanceKind(value: unknown, fallback = DEMO_TELM_BALANCE_KIND) {
+  return value === PAID_ELM_BALANCE_KIND || value === DEMO_TELM_BALANCE_KIND ? value : fallback;
+}
+
+function botAccountIdForBalanceKind(balanceKind: string) {
+  return `${BOT_ACCOUNT_PREFIX}:${normalizeBalanceKind(balanceKind)}`;
+}
+
+function botIdentityForBalanceKind(balanceKind: string) {
+  return normalizeBalanceKind(balanceKind) === PAID_ELM_BALANCE_KIND ? PAID_BOT_IDENTITY : DEMO_BOT_IDENTITY;
+}
+
+function initialBalanceForBalanceKind(balanceKind: string) {
+  return normalizeBalanceKind(balanceKind) === PAID_ELM_BALANCE_KIND ? 0 : INITIAL_BALANCE;
+}
+
+function migratedBalanceForBalanceKind(ctx: ReducerContext, accountId: string, balanceKind: string) {
+  if (normalizeBalanceKind(balanceKind) !== PAID_ELM_BALANCE_KIND) {
+    return initialBalanceForBalanceKind(balanceKind);
+  }
+
+  let credited = 0;
+  for (const row of ctx.db.paymentLedger.iter()) {
+    if (row.accountId !== accountId || row.status !== PAYMENT_STATUS_CREDITED) continue;
+    credited += Math.max(0, (row.elmAmount ?? 0) - (row.refundedElmAmount ?? 0));
+  }
+  return credited;
+}
+
+function assertSameEntryBalanceKind(p1Entry: QueueEntryRow, p2Entry: QueueEntryRow) {
+  const p1Kind = entryBalanceKind(p1Entry);
+  const p2Kind = entryBalanceKind(p2Entry);
+  if (p1Kind !== p2Kind) {
+    throw new SenderError('Cannot match paid ELM and demo tELM accounts');
+  }
+  return p1Kind;
+}
+
+function currencyLabelForBalanceKind(balanceKind: string) {
+  return normalizeBalanceKind(balanceKind) === PAID_ELM_BALANCE_KIND ? 'ELM' : 'tELM';
 }
 
 function enforceJoinQueueRateLimit(ctx: ReducerContext, now: bigint) {

--- a/apps/tma/src/module_bindings/account_table.ts
+++ b/apps/tma/src/module_bindings/account_table.ts
@@ -17,4 +17,5 @@ export default __t.row({
   wins: __t.u32(),
   losses: __t.u32(),
   balance: __t.i32(),
+  balanceKind: __t.string().name("balance_kind"),
 });

--- a/apps/tma/src/module_bindings/match_state_table.ts
+++ b/apps/tma/src/module_bindings/match_state_table.ts
@@ -19,6 +19,7 @@ export default __t.row({
   p1Rating: __t.i32().name("p_1_rating"),
   p2Rating: __t.i32().name("p_2_rating"),
   stake: __t.u32(),
+  balanceKind: __t.string().name("balance_kind"),
   mode: __t.string(),
   room: __t.string(),
   phase: __t.string(),

--- a/apps/tma/src/module_bindings/player_table.ts
+++ b/apps/tma/src/module_bindings/player_table.ts
@@ -18,5 +18,6 @@ export default __t.row({
   wins: __t.u32(),
   losses: __t.u32(),
   balance: __t.i32(),
+  balanceKind: __t.string().name("balance_kind"),
   accountId: __t.string().name("account_id"),
 });

--- a/apps/tma/src/module_bindings/queue_entry_table.ts
+++ b/apps/tma/src/module_bindings/queue_entry_table.ts
@@ -21,4 +21,5 @@ export default __t.row({
   joinedAtMicros: __t.u64().name("joined_at_micros"),
   botFallbackAtMicros: __t.option(__t.u64()).name("bot_fallback_at_micros"),
   accountId: __t.string().name("account_id"),
+  balanceKind: __t.string().name("balance_kind"),
 });

--- a/apps/tma/src/module_bindings/types.ts
+++ b/apps/tma/src/module_bindings/types.ts
@@ -17,6 +17,7 @@ export const Account = __t.object("Account", {
   wins: __t.u32(),
   losses: __t.u32(),
   balance: __t.i32(),
+  balanceKind: __t.string(),
 });
 export type Account = __Infer<typeof Account>;
 
@@ -65,6 +66,7 @@ export const MatchState = __t.object("MatchState", {
   p1Rating: __t.i32(),
   p2Rating: __t.i32(),
   stake: __t.u32(),
+  balanceKind: __t.string(),
   mode: __t.string(),
   room: __t.string(),
   phase: __t.string(),
@@ -120,6 +122,7 @@ export const Player = __t.object("Player", {
   wins: __t.u32(),
   losses: __t.u32(),
   balance: __t.i32(),
+  balanceKind: __t.string(),
   accountId: __t.string(),
 });
 export type Player = __Infer<typeof Player>;
@@ -135,6 +138,7 @@ export const QueueEntry = __t.object("QueueEntry", {
   joinedAtMicros: __t.u64(),
   botFallbackAtMicros: __t.option(__t.u64()),
   accountId: __t.string(),
+  balanceKind: __t.string(),
 });
 export type QueueEntry = __Infer<typeof QueueEntry>;
 

--- a/apps/tma/src/screens/HomeScreen.tsx
+++ b/apps/tma/src/screens/HomeScreen.tsx
@@ -12,6 +12,7 @@ import {
   type ElmStarsPackageId,
   type TelegramInvoiceStatus,
 } from '../services/payments';
+import { currencyForUser, formatCurrencyAmount } from '../services/economy';
 import { SwordsIcon } from '../components/icons/SwordsIcon';
 import { SkullIcon } from '../components/icons/SkullIcon';
 import { VortexIcon } from '../components/icons/VortexIcon';
@@ -77,6 +78,7 @@ export function HomeScreen() {
 
   const stakeRequired = 100 + (boostEnabled ? 10 : 0);
   const canAffordMatch = elmBalance >= stakeRequired;
+  const currency = currencyForUser(telegramUser);
   const showStarsTopUp = telegramUser?.source === 'telegram' && Boolean(telegramUser.initData);
   const pendingPackageId = topUpState.status === 'loading' ? topUpState.packageId : undefined;
 
@@ -171,7 +173,7 @@ export function HomeScreen() {
           </div>
         </motion.div>
 
-        {/* ELM Balance card */}
+        {/* Balance card */}
         <motion.div
           className="glass-card p-5 text-center"
           initial={{ opacity: 0, scale: 0.95 }}
@@ -179,7 +181,7 @@ export function HomeScreen() {
           transition={{ delay: 0.1 }}
         >
           <div className="text-xs text-text-secondary font-semibold tracking-widest uppercase mb-1">
-            ELM Balance
+            {currency} Balance
           </div>
           <motion.div
             className="glow-text-gold text-5xl font-black tabular-nums"
@@ -379,13 +381,13 @@ export function HomeScreen() {
                 PLAY NOW
               </span>
             ) : (
-              'NOT ENOUGH ELM'
+              `NOT ENOUGH ${currency}`
             )}
           </motion.button>
           <div className="text-xs text-text-muted">
             {canAffordMatch
-              ? `Stake: ${stakeRequired} ELM • ${gameMode} mode`
-              : `Need ${stakeRequired} ELM (have ${elmBalance})`}
+              ? `Stake: ${formatCurrencyAmount(stakeRequired, currency)} • ${gameMode} mode`
+              : `Need ${formatCurrencyAmount(stakeRequired, currency)} (have ${formatCurrencyAmount(elmBalance, currency)})`}
           </div>
         </motion.div>
 

--- a/apps/tma/src/screens/ProfileScreen.tsx
+++ b/apps/tma/src/screens/ProfileScreen.tsx
@@ -5,6 +5,7 @@ import { updatePlayerProfile } from '../services/gameService';
 import { haptic, sanitizeWebUserName, saveWebUser } from '../services/telegram';
 import { playerDisplayName, playerFullName } from '../services/playerProfile';
 import { opponentWinRate } from '../services/opponentStats';
+import { currencyForUser, formatCurrencyAmount } from '../services/economy';
 import { ArrowLeftIcon } from '../components/icons/ArrowLeftIcon';
 import { StarIcon } from '../components/icons/StarIcon';
 import { CheckIcon } from '../components/icons/CheckIcon';
@@ -24,6 +25,7 @@ export function ProfileScreen() {
       ? `@${telegramUser.username}`
       : '';
   const isWebUser = telegramUser?.source === 'web';
+  const currency = currencyForUser(telegramUser);
   const [draftName, setDraftName] = useState(displayName);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle');
   const cleanDraftName = useMemo(() => sanitizeWebUserName(draftName), [draftName]);
@@ -175,14 +177,14 @@ export function ProfileScreen() {
           </div>
         </motion.div>
 
-        {/* ELM Balance */}
+        {/* Balance */}
         <motion.div
           className="glass-card p-4 text-center"
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.05 }}
         >
-          <div className="text-xs text-text-secondary uppercase tracking-widest mb-2">ELM Balance</div>
+          <div className="text-xs text-text-secondary uppercase tracking-widest mb-2">{currency} Balance</div>
           <div className="glow-text-gold text-4xl font-black">{elmBalance.toLocaleString()}</div>
           <div className="text-xs text-text-muted mt-1">tokens</div>
         </motion.div>
@@ -352,7 +354,7 @@ export function ProfileScreen() {
                       <span className="text-text-secondary text-xs truncate">{tx.description}</span>
                     </div>
                     <span className="font-bold text-xs ml-2 flex-shrink-0" style={{ color }}>
-                      {tx.amount > 0 ? '+' : ''}{tx.amount !== 0 ? tx.amount : '—'}
+                      {tx.amount !== 0 ? formatCurrencyAmount(tx.amount, currency, { signed: true }) : '—'}
                     </span>
                   </div>
                 );

--- a/apps/tma/src/screens/ResultScreen.tsx
+++ b/apps/tma/src/screens/ResultScreen.tsx
@@ -5,6 +5,7 @@ import { RAKE_PERCENT, getMoveInfo } from '@elmental/shared';
 import { haptic } from '../services/telegram';
 import { applyResults } from '../services/gameService';
 import { playSound } from '../services/audio';
+import { currencyForUser, formatCurrencyAmount } from '../services/economy';
 import { TrophyIcon } from '../components/icons/TrophyIcon';
 import { SkullIcon } from '../components/icons/SkullIcon';
 import { HandshakeIcon } from '../components/icons/HandshakeIcon';
@@ -47,7 +48,9 @@ export function ResultScreen() {
     roundHistory,
     resetMatch,
     setScreen,
+    telegramUser,
   } = useGameStore();
+  const currency = currencyForUser(telegramUser);
 
   const hasFiredHaptic = useRef(false);
 
@@ -199,7 +202,7 @@ export function ResultScreen() {
           </div>
         </motion.div>
 
-        {/* ELM + Rating changes */}
+        {/* Economy + Rating changes */}
         <motion.div
           className="glass-card p-4 w-full"
           initial={{ opacity: 0, y: 20 }}
@@ -209,7 +212,7 @@ export function ResultScreen() {
           <div className="flex items-center justify-between py-1.5">
             <div className="flex items-center gap-2">
               <CoinsIcon size={18} className="text-gold" />
-              <span className="text-sm text-text-secondary">ELM Change</span>
+              <span className="text-sm text-text-secondary">{currency} Change</span>
             </div>
             <span
               className="text-lg font-black"
@@ -217,7 +220,7 @@ export function ResultScreen() {
                 color: matchResult.elmEarned >= 0 ? '#22c55e' : '#ef4444',
               }}
             >
-              {matchResult.elmEarned >= 0 ? '+' : ''}{matchResult.elmEarned}
+              {formatCurrencyAmount(matchResult.elmEarned, currency, { signed: true })}
             </span>
           </div>
           <div
@@ -254,20 +257,20 @@ export function ResultScreen() {
             <div className="flex flex-col gap-1.5 text-sm">
               <div className="flex justify-between">
                 <span className="text-text-secondary">Stake</span>
-                <span className="text-text-primary">{matchResult.stake} ELM</span>
+                <span className="text-text-primary">{formatCurrencyAmount(matchResult.stake, currency)}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-text-secondary">Total Pool</span>
-                <span className="text-text-primary">{matchResult.totalPool} ELM</span>
+                <span className="text-text-primary">{formatCurrencyAmount(matchResult.totalPool, currency)}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-text-secondary">Rake ({RAKE_PERCENT}%)</span>
-                <span className="text-energy-low">-{matchResult.rake} ELM</span>
+                <span className="text-energy-low">{formatCurrencyAmount(-matchResult.rake, currency)}</span>
               </div>
               {isWin && (
                 <div className="flex justify-between">
                   <span className="text-text-secondary">Winner Payout</span>
-                  <span className="text-energy-high font-bold">+{matchResult.winnerPayout} ELM</span>
+                  <span className="text-energy-high font-bold">{formatCurrencyAmount(matchResult.winnerPayout, currency, { signed: true })}</span>
                 </div>
               )}
               {matchResult.boostStake > 0 && (
@@ -275,7 +278,7 @@ export function ResultScreen() {
                   <div className="my-1 h-px" style={{ background: 'rgba(255,255,255,0.06)' }} />
                   <div className="flex justify-between">
                     <span className="text-text-secondary">Boost Stake</span>
-                    <span className="text-text-primary">{matchResult.boostStake} ELM</span>
+                    <span className="text-text-primary">{formatCurrencyAmount(matchResult.boostStake, currency)}</span>
                   </div>
                   <div className="flex justify-between">
                     <span className="text-text-secondary">Boost Status</span>
@@ -293,7 +296,7 @@ export function ResultScreen() {
               <div className="flex justify-between text-base font-bold">
                 <span className="text-text-primary">Net Result</span>
                 <span style={{ color: matchResult.elmEarned >= 0 ? '#22c55e' : '#ef4444' }}>
-                  {matchResult.elmEarned >= 0 ? '+' : ''}{matchResult.elmEarned} ELM
+                  {formatCurrencyAmount(matchResult.elmEarned, currency, { signed: true })}
                 </span>
               </div>
             </div>

--- a/apps/tma/src/services/bugReport.test.ts
+++ b/apps/tma/src/services/bugReport.test.ts
@@ -40,15 +40,23 @@ describe('bug report issue builder', () => {
   });
 
   it('formats the report as JSON inside markdown', () => {
-    const body = formatBugReportBody(snapshot([]));
+    const body = formatBugReportBody(snapshot([], {
+      economy: {
+        currency: 'tELM',
+        balanceKind: 'demo_teml',
+        balance: 1000,
+      },
+    }));
 
     expect(body).toContain('## Session report');
     expect(body).toContain('```json');
     expect(body).toContain('"database": "elmental-v2"');
+    expect(body).toContain('"currency": "tELM"');
+    expect(body).toContain('"balanceKind": "demo_teml"');
   });
 });
 
-function snapshot(logs: BugReportSnapshot['logs']): BugReportSnapshot {
+function snapshot(logs: BugReportSnapshot['logs'], game: Record<string, unknown> = {}): BugReportSnapshot {
   return {
     generatedAt: '2026-05-16T12:00:00.000Z',
     app: {
@@ -66,6 +74,7 @@ function snapshot(logs: BugReportSnapshot['logs']): BugReportSnapshot {
       matchStatus: 'playing',
       currentRound: 2,
       roundPhase: 'select',
+      ...game,
     },
     logs,
   };

--- a/apps/tma/src/services/bugReport.ts
+++ b/apps/tma/src/services/bugReport.ts
@@ -1,4 +1,5 @@
 import { useGameStore } from '../stores/gameStore';
+import { balanceKindForUser, currencyForUser } from './economy';
 import { getBotFallbackSeconds, getDatabaseName, getMatchRoom, getSpacetimeUri } from './gameProvider/spacetimeProvider';
 
 const ISSUE_URL = 'https://github.com/elemgame/elemgameV2/issues/new';
@@ -169,6 +170,8 @@ function compactLogs(logs: BugReportLogEntry[]): BugReportLogEntry[] {
 
 function gameSnapshot(): Record<string, unknown> {
   const state = useGameStore.getState();
+  const currency = currencyForUser(state.telegramUser);
+  const balanceKind = balanceKindForUser(state.telegramUser);
   return {
     currentScreen: state.currentScreen,
     matchStatus: state.matchStatus,
@@ -193,6 +196,11 @@ function gameSnapshot(): Record<string, unknown> {
     opponentStats: state.opponentStats,
     rating: state.rating,
     elmBalance: state.elmBalance,
+    economy: {
+      currency,
+      balanceKind,
+      balance: state.elmBalance,
+    },
     user: state.telegramUser
       ? {
           id: state.telegramUser.id,

--- a/apps/tma/src/services/economy.ts
+++ b/apps/tma/src/services/economy.ts
@@ -1,0 +1,17 @@
+import type { PlayerProfileInput } from './gameProvider/types';
+
+export type EconomyCurrency = 'ELM' | 'tELM';
+export type EconomyBalanceKind = 'paid_elm' | 'demo_teml';
+
+export function currencyForUser(user?: Pick<PlayerProfileInput, 'source'> | null): EconomyCurrency {
+  return user?.source === 'telegram' ? 'ELM' : 'tELM';
+}
+
+export function balanceKindForUser(user?: Pick<PlayerProfileInput, 'source'> | null): EconomyBalanceKind {
+  return user?.source === 'telegram' ? 'paid_elm' : 'demo_teml';
+}
+
+export function formatCurrencyAmount(amount: number, currency: EconomyCurrency, options: { signed?: boolean } = {}): string {
+  const sign = options.signed && amount > 0 ? '+' : '';
+  return `${sign}${amount.toLocaleString()} ${currency}`;
+}

--- a/apps/tma/src/services/gameProvider/spacetimeProvider.test.ts
+++ b/apps/tma/src/services/gameProvider/spacetimeProvider.test.ts
@@ -106,6 +106,7 @@ describe('SpacetimeDB provider mappers', () => {
       p1Rating: 1210,
       p2Rating: 1180,
       stake: 100,
+      balanceKind: 'demo_teml',
       mode: 'classic',
       room: 'test',
       phase: 'commit',

--- a/apps/tma/src/services/gameService.ts
+++ b/apps/tma/src/services/gameService.ts
@@ -9,6 +9,7 @@ import { useGameStore, type EconomyTransaction, type EnergyLevel } from '../stor
 import { showAlert } from './telegram';
 import { playSound } from './audio';
 import { playerAccountId, playerDisplayName } from './playerProfile';
+import { currencyForUser, formatCurrencyAmount } from './economy';
 import { createMockProvider } from './gameProvider/mockProvider';
 import { recordGameLog } from './bugReport';
 import {
@@ -220,6 +221,7 @@ function applyMatchFound(event: Extract<GameplayProviderEvent, { type: 'matchFou
 
   if (!deductedMatchIds.has(event.matchId)) {
     deductedMatchIds.add(event.matchId);
+    const currency = activeCurrency();
     if (FORCE_MOCK) {
       store.setPlayerStats({
         elmBalance: store.elmBalance - event.stake - event.boostStake,
@@ -228,9 +230,9 @@ function applyMatchFound(event: Extract<GameplayProviderEvent, { type: 'matchFou
         losses: store.stats.losses,
       });
     }
-    addTx('stake', -event.stake, event.matchId, `Staked ${event.stake} ELM for match vs ${event.opponentName}`);
+    addTx('stake', -event.stake, event.matchId, `Staked ${formatCurrencyAmount(event.stake, currency)} for match vs ${event.opponentName}`);
     if (event.boostStake > 0) {
-      addTx('stake', -event.boostStake, event.matchId, `Energy Boost investment: ${event.boostStake} ELM`);
+      addTx('stake', -event.boostStake, event.matchId, `Energy Boost investment: ${formatCurrencyAmount(event.boostStake, currency)}`);
     }
   }
 
@@ -312,6 +314,7 @@ function applyMatchSettled(event: Extract<GameplayProviderEvent, { type: 'matchS
   const isDraw = event.winner === 'draw';
   const { winnerPayout, rake } = calculatePayout(event.stake, RAKE_PERCENT);
   const boostStake = store.matchBoostStake;
+  const currency = activeCurrency();
 
   let ratingDelta = 0;
   if (!isDraw) {
@@ -322,15 +325,15 @@ function applyMatchSettled(event: Extract<GameplayProviderEvent, { type: 'matchS
   let balanceDelta = 0;
   if (isDraw) {
     balanceDelta = event.stake + boostStake;
-    addTx('win', event.stake, event.matchId, `Draw. Stake refunded: ${event.stake} ELM`);
-    if (boostStake > 0) addTx('boost_return', boostStake, event.matchId, `Boost refunded: ${boostStake} ELM`);
+    addTx('win', event.stake, event.matchId, `Draw. Stake refunded: ${formatCurrencyAmount(event.stake, currency)}`);
+    if (boostStake > 0) addTx('boost_return', boostStake, event.matchId, `Boost refunded: ${formatCurrencyAmount(boostStake, currency)}`);
   } else if (won) {
     balanceDelta = winnerPayout + boostStake;
-    addTx('win', winnerPayout, event.matchId, `Won. Payout: ${winnerPayout} ELM`);
-    if (boostStake > 0) addTx('boost_return', boostStake, event.matchId, `Boost returned: ${boostStake} ELM`);
+    addTx('win', winnerPayout, event.matchId, `Won. Payout: ${formatCurrencyAmount(winnerPayout, currency)}`);
+    if (boostStake > 0) addTx('boost_return', boostStake, event.matchId, `Boost returned: ${formatCurrencyAmount(boostStake, currency)}`);
   } else {
-    addTx('loss', -event.stake, event.matchId, `Lost match. Stake ${event.stake} ELM forfeited.`);
-    if (boostStake > 0) addTx('boost_burn', -boostStake, event.matchId, `Boost burned: ${boostStake} ELM`);
+    addTx('loss', -event.stake, event.matchId, `Lost match. Stake ${formatCurrencyAmount(event.stake, currency)} forfeited.`);
+    if (boostStake > 0) addTx('boost_burn', -boostStake, event.matchId, `Boost burned: ${formatCurrencyAmount(boostStake, currency)}`);
   }
 
   if (FORCE_MOCK) {
@@ -420,7 +423,7 @@ function addTx(type: EconomyTransaction['type'], amount: number, matchId: string
 
 function matchmakingErrorMessage(message: string): string {
   if (FORCE_MOCK) return 'Mock matchmaking is unavailable.';
-  if (message.includes('Insufficient ELM balance')) return message;
+  if (message.includes('Insufficient ') && message.includes(' balance')) return message;
   return 'SpacetimeDB matchmaking is unavailable. Check the backend logs and try again.';
 }
 
@@ -437,4 +440,9 @@ function trace(event: string, data: Record<string, unknown>): void {
   recordGameLog('info', event, data);
   if (!TRACE_ENABLED) return;
   console.info(`[elmental:client] ${event}`, data);
+}
+
+function activeCurrency() {
+  const store = useGameStore.getState();
+  return currencyForUser(store.telegramUser ?? currentUser);
 }


### PR DESCRIPTION
## Summary

- Add `balanceKind` to SpacetimeDB account/player/queue/match rows and generated bindings.
- Split Telegram paid `ELM` from web demo `tELM` by account id, initial balance, bot account/identity, and matchmaking eligibility.
- Prevent old Telegram demo balances from becoming paid ELM while preserving any credited paid balance from payment ledger rows.
- Label web balances, stakes, payouts, result economics, and transaction history as `tELM`; Telegram sessions keep `ELM` and Stars controls.
- Include economy currency/balance kind in bug report snapshots.

## Validation

- `spacetime build --module-path apps/spacetime/spacetimedb`
- `pnpm stdb:generate`
- `spacetime generate --lang typescript --out-dir apps/payments/src/module_bindings --module-path apps/spacetime/spacetimedb`
- `pnpm --filter @elmental/tma test -- run`
- `pnpm --filter @elmental/tma build`
- `pnpm --filter @elmental/payments build`
- `pnpm --filter @elmental/payments test`
- `pnpm test:stdb-local-scenarios`
- Playwright browser smoke: web/demo shows `tELM` and hides top-up; Telegram-like runtime shows `ELM` and top-up.

Closes #35.

Stacked on #44.
