### PR TITLE
[codex] Carry balance kind through PvP stake events

### DIFF
--- a/apps/tma/src/screens/ResultScreen.tsx
+++ b/apps/tma/src/screens/ResultScreen.tsx
@@ -5,7 +5,7 @@ import { RAKE_PERCENT, getMoveInfo } from '@elmental/shared';
 import { haptic } from '../services/telegram';
 import { applyResults } from '../services/gameService';
 import { playSound } from '../services/audio';
-import { currencyForUser, formatCurrencyAmount } from '../services/economy';
+import { currencyForBalanceKind, formatCurrencyAmount } from '../services/economy';
 import { TrophyIcon } from '../components/icons/TrophyIcon';
 import { SkullIcon } from '../components/icons/SkullIcon';
 import { HandshakeIcon } from '../components/icons/HandshakeIcon';
@@ -48,9 +48,7 @@ export function ResultScreen() {
     roundHistory,
     resetMatch,
     setScreen,
-    telegramUser,
   } = useGameStore();
-  const currency = currencyForUser(telegramUser);
 
   const hasFiredHaptic = useRef(false);
 
@@ -93,6 +91,7 @@ export function ResultScreen() {
   const isWin = matchResult.winner === 'me';
   const isDraw = matchResult.winner === 'draw';
   const isLose = matchResult.winner === 'opponent';
+  const currency = currencyForBalanceKind(matchResult.balanceKind);
 
   const resultConfig = isWin
     ? {

--- a/apps/tma/src/services/bugReport.test.ts
+++ b/apps/tma/src/services/bugReport.test.ts
@@ -44,6 +44,7 @@ describe('bug report issue builder', () => {
       economy: {
         currency: 'tELM',
         balanceKind: 'demo_teml',
+        matchBalanceKind: 'demo_teml',
         balance: 1000,
       },
     }));
@@ -53,6 +54,7 @@ describe('bug report issue builder', () => {
     expect(body).toContain('"database": "elmental-v2"');
     expect(body).toContain('"currency": "tELM"');
     expect(body).toContain('"balanceKind": "demo_teml"');
+    expect(body).toContain('"matchBalanceKind": "demo_teml"');
   });
 });
 

--- a/apps/tma/src/services/bugReport.ts
+++ b/apps/tma/src/services/bugReport.ts
@@ -176,6 +176,7 @@ function gameSnapshot(): Record<string, unknown> {
     currentScreen: state.currentScreen,
     matchStatus: state.matchStatus,
     matchId: state.matchId,
+    matchBalanceKind: state.matchBalanceKind,
     isPlayer1: state.isPlayer1,
     opponentName: state.opponentName,
     opponentRating: state.opponentRating,
@@ -199,6 +200,7 @@ function gameSnapshot(): Record<string, unknown> {
     economy: {
       currency,
       balanceKind,
+      matchBalanceKind: state.matchBalanceKind,
       balance: state.elmBalance,
     },
     user: state.telegramUser

--- a/apps/tma/src/services/economy.ts
+++ b/apps/tma/src/services/economy.ts
@@ -3,8 +3,16 @@ import type { PlayerProfileInput } from './gameProvider/types';
 export type EconomyCurrency = 'ELM' | 'tELM';
 export type EconomyBalanceKind = 'paid_elm' | 'demo_teml';
 
+export function normalizeBalanceKind(value?: string | null): EconomyBalanceKind {
+  return value === 'paid_elm' ? 'paid_elm' : 'demo_teml';
+}
+
 export function currencyForUser(user?: Pick<PlayerProfileInput, 'source'> | null): EconomyCurrency {
   return user?.source === 'telegram' ? 'ELM' : 'tELM';
+}
+
+export function currencyForBalanceKind(balanceKind?: string | null): EconomyCurrency {
+  return normalizeBalanceKind(balanceKind) === 'paid_elm' ? 'ELM' : 'tELM';
 }
 
 export function balanceKindForUser(user?: Pick<PlayerProfileInput, 'source'> | null): EconomyBalanceKind {

--- a/apps/tma/src/services/gameProvider/mockProvider.test.ts
+++ b/apps/tma/src/services/gameProvider/mockProvider.test.ts
@@ -54,6 +54,7 @@ describe('mock gameplay provider contract', () => {
     expect(roundResults).toHaveLength(3);
     expect(roundResults[0]).toMatchObject({
       type: 'roundResult',
+      balanceKind: 'demo_teml',
       myEnergyBefore: 100,
       myEnergyAfter: 95,
     });
@@ -63,6 +64,7 @@ describe('mock gameplay provider contract', () => {
     });
     expect(events.at(-1)).toMatchObject({
       type: 'matchSettled',
+      balanceKind: 'demo_teml',
       winner: 'me',
       myScore: 3,
       opponentScore: 0,
@@ -150,6 +152,7 @@ describe('mock gameplay provider contract', () => {
     expect(events.find((event) => event.type === 'playerStats')).toMatchObject({
       type: 'playerStats',
       name: 'tg_nick',
+      balanceKind: 'paid_elm',
     });
   });
 

--- a/apps/tma/src/services/gameProvider/mockProvider.ts
+++ b/apps/tma/src/services/gameProvider/mockProvider.ts
@@ -11,6 +11,7 @@ import {
   resolveRound,
 } from '@elmental/shared';
 import { playerDisplayName } from '../playerProfile';
+import { balanceKindForUser } from '../economy';
 import type {
   GameplayProvider,
   GameplayProviderContext,
@@ -74,6 +75,7 @@ export function createMockProvider(
         type: 'playerStats',
         name: displayName(user),
         elmBalance: 1000,
+        balanceKind: balanceKindForUser(user),
         rating: 1200,
         wins: 12,
         losses: 8,
@@ -87,6 +89,7 @@ export function createMockProvider(
         type: 'playerStats',
         name: displayName(user),
         elmBalance: 1000,
+        balanceKind: balanceKindForUser(user),
         rating: 1200,
         wins: 12,
         losses: 8,
@@ -101,6 +104,7 @@ export function createMockProvider(
         room: request.room,
         mode: request.mode,
         stake: request.stake,
+        balanceKind: activeBalanceKind(),
       });
 
       schedule(() => {
@@ -127,6 +131,7 @@ export function createMockProvider(
         context.emit({
           type: 'matchFound',
           matchId: match.id,
+          balanceKind: activeBalanceKind(),
           opponentName,
           opponentRating,
           isPlayer1: true,
@@ -236,6 +241,7 @@ export function createMockProvider(
     context.emit({
       type: 'roundResult',
       matchId: match.id,
+      balanceKind: activeBalanceKind(),
       round: match.currentRound,
       myMove: finalPlayerMove,
       opponentMove,
@@ -278,6 +284,7 @@ export function createMockProvider(
     context.emit({
       type: 'matchUpdate',
       matchId: match.id,
+      balanceKind: activeBalanceKind(),
       phase: match.phase === 'result' ? 'result' : match.phase,
       status: 'active',
       currentRound: match.currentRound,
@@ -295,6 +302,7 @@ export function createMockProvider(
     context.emit({
       type: 'matchSettled',
       matchId: match.id,
+      balanceKind: activeBalanceKind(),
       winner,
       myScore: match.myScore,
       opponentScore: match.opponentScore,
@@ -320,6 +328,10 @@ export function createMockProvider(
 
   function trace(event: string, data: Record<string, unknown>): void {
     context.emit({ type: 'trace', event, data });
+  }
+
+  function activeBalanceKind(): string {
+    return balanceKindForUser(currentUser);
   }
 
   return provider;

--- a/apps/tma/src/services/gameProvider/spacetimeProvider.test.ts
+++ b/apps/tma/src/services/gameProvider/spacetimeProvider.test.ts
@@ -70,6 +70,7 @@ describe('SpacetimeDB provider mappers', () => {
 
     expect(p1Result).toMatchObject({
       type: 'roundResult',
+      balanceKind: 'demo_teml',
       myMove: MoveId.Fire,
       opponentMove: MoveId.Earth,
       result: 'win',
@@ -80,6 +81,7 @@ describe('SpacetimeDB provider mappers', () => {
     });
     expect(p2Result).toMatchObject({
       type: 'roundResult',
+      balanceKind: 'demo_teml',
       myMove: MoveId.Earth,
       opponentMove: MoveId.Fire,
       result: 'lose',

--- a/apps/tma/src/services/gameProvider/spacetimeProvider.ts
+++ b/apps/tma/src/services/gameProvider/spacetimeProvider.ts
@@ -250,6 +250,7 @@ export function createSpacetimeProvider(
     trace('spacetime.player.update', {
       name: row.name,
       balance: row.balance,
+      balanceKind: row.balanceKind,
       rating: row.rating,
       wins: row.wins,
       losses: row.losses,
@@ -258,6 +259,7 @@ export function createSpacetimeProvider(
       type: 'playerStats',
       name: row.name,
       elmBalance: row.balance,
+      balanceKind: row.balanceKind,
       rating: row.rating,
       wins: row.wins,
       losses: row.losses,
@@ -271,8 +273,9 @@ export function createSpacetimeProvider(
       room: row.room,
       mode: row.mode,
       stake: row.stake,
+      balanceKind: row.balanceKind,
     });
-    context.emit({ type: 'queueActive', name: row.name, room: row.room, mode: row.mode, stake: row.stake });
+    context.emit({ type: 'queueActive', name: row.name, room: row.room, mode: row.mode, stake: row.stake, balanceKind: row.balanceKind });
   }
 
   function handleQueueRemoved(row: QueueEntry): void {
@@ -282,8 +285,9 @@ export function createSpacetimeProvider(
       room: row.room,
       mode: row.mode,
       stake: row.stake,
+      balanceKind: row.balanceKind,
     });
-    context.emit({ type: 'queueRemoved', name: row.name, room: row.room, mode: row.mode, stake: row.stake });
+    context.emit({ type: 'queueRemoved', name: row.name, room: row.room, mode: row.mode, stake: row.stake, balanceKind: row.balanceKind });
   }
 
   function handleMatch(row: MatchState): void {
@@ -322,6 +326,7 @@ export function createSpacetimeProvider(
       matchId: perspective.matchId,
       phase: row.phase,
       status: row.status,
+      balanceKind: row.balanceKind,
       round: row.currentRound,
       p1: row.p1Name,
       p2: row.p2Name,
@@ -335,6 +340,7 @@ export function createSpacetimeProvider(
       context.emit({
         type: 'matchFound',
         matchId: perspective.matchId,
+        balanceKind: row.balanceKind,
         opponentName: perspective.opponentName,
         opponentRating: perspective.opponentRating,
         isPlayer1: perspective.isPlayer1,
@@ -351,6 +357,7 @@ export function createSpacetimeProvider(
         context.emit({
           type: 'matchUpdate',
           matchId: perspective.matchId,
+          balanceKind: row.balanceKind,
           phase: mapRoundPhase(row.phase, selectedMove),
           status: 'active',
           currentRound: row.currentRound,
@@ -396,6 +403,7 @@ export function createSpacetimeProvider(
       p2Move: row.p2Move,
       result: result.result,
       score: `${row.p1Score}:${row.p2Score}`,
+      balanceKind: activeMatch.balanceKind,
     });
     context.emit(result);
   }
@@ -443,6 +451,7 @@ export function createSpacetimeProvider(
       context.emit({
         type: 'matchSettled',
         matchId: perspective.matchId,
+        balanceKind: row.balanceKind,
         winner: row.winner === undefined
           ? 'draw'
           : isWinnerForPerspective(row, perspective)
@@ -769,6 +778,7 @@ export function mapRoundResultPerspective(
   return {
     type: 'roundResult' as const,
     matchId: row.matchId.toString(),
+    balanceKind: match.balanceKind,
     round: row.round,
     myMove: (isPlayer1 ? row.p1Move : row.p2Move) as MoveId,
     opponentMove: (isPlayer1 ? row.p2Move : row.p1Move) as MoveId,

--- a/apps/tma/src/services/gameProvider/types.ts
+++ b/apps/tma/src/services/gameProvider/types.ts
@@ -26,6 +26,7 @@ export interface MatchmakingRequest {
 export interface MatchFoundEvent {
   type: 'matchFound';
   matchId: string;
+  balanceKind: string;
   opponentName: string;
   opponentRating: number;
   isPlayer1: boolean;
@@ -41,6 +42,7 @@ export interface MatchFoundEvent {
 export interface MatchUpdateEvent {
   type: 'matchUpdate';
   matchId: string;
+  balanceKind: string;
   phase: ProviderRoundPhase;
   status: 'active' | 'settled';
   currentRound: number;
@@ -54,6 +56,7 @@ export interface MatchUpdateEvent {
 export interface RoundResultEvent {
   type: 'roundResult';
   matchId: string;
+  balanceKind: string;
   round: number;
   myMove: MoveId;
   opponentMove: MoveId;
@@ -69,6 +72,7 @@ export interface RoundResultEvent {
 export interface MatchSettledEvent {
   type: 'matchSettled';
   matchId: string;
+  balanceKind: string;
   winner: 'me' | 'opponent' | 'draw';
   myScore: number;
   opponentScore: number;
@@ -80,9 +84,9 @@ export interface MatchSettledEvent {
 export type GameplayProviderEvent =
   | { type: 'trace'; event: string; data: Record<string, unknown> }
   | { type: 'error'; code: string; message: string; source: string; metadata?: Record<string, unknown> }
-  | { type: 'playerStats'; name: string; elmBalance: number; rating: number; wins: number; losses: number }
-  | { type: 'queueActive'; name: string; room: string; mode: string; stake: number }
-  | { type: 'queueRemoved'; name: string; room: string; mode: string; stake: number }
+  | { type: 'playerStats'; name: string; elmBalance: number; balanceKind: string; rating: number; wins: number; losses: number }
+  | { type: 'queueActive'; name: string; room: string; mode: string; stake: number; balanceKind: string }
+  | { type: 'queueRemoved'; name: string; room: string; mode: string; stake: number; balanceKind: string }
   | MatchFoundEvent
   | MatchUpdateEvent
   | RoundResultEvent

--- a/apps/tma/src/services/gameService.ts
+++ b/apps/tma/src/services/gameService.ts
@@ -9,7 +9,7 @@ import { useGameStore, type EconomyTransaction, type EnergyLevel } from '../stor
 import { showAlert } from './telegram';
 import { playSound } from './audio';
 import { playerAccountId, playerDisplayName } from './playerProfile';
-import { currencyForUser, formatCurrencyAmount } from './economy';
+import { currencyForBalanceKind, formatCurrencyAmount } from './economy';
 import { createMockProvider } from './gameProvider/mockProvider';
 import { recordGameLog } from './bugReport';
 import {
@@ -168,6 +168,10 @@ function handleProviderEvent(event: GameplayProviderEvent): void {
       return;
 
     case 'playerStats':
+      trace('player.stats', {
+        balance: event.elmBalance,
+        balanceKind: event.balanceKind,
+      });
       useGameStore.getState().setPlayerStats({
         elmBalance: event.elmBalance,
         rating: event.rating,
@@ -221,7 +225,7 @@ function applyMatchFound(event: Extract<GameplayProviderEvent, { type: 'matchFou
 
   if (!deductedMatchIds.has(event.matchId)) {
     deductedMatchIds.add(event.matchId);
-    const currency = activeCurrency();
+    const currency = currencyForBalanceKind(event.balanceKind);
     if (FORCE_MOCK) {
       store.setPlayerStats({
         elmBalance: store.elmBalance - event.stake - event.boostStake,
@@ -241,9 +245,10 @@ function applyMatchFound(event: Extract<GameplayProviderEvent, { type: 'matchFou
     opponentName: event.opponentName,
     opponentRating: event.opponentRating,
     isPlayer1: event.isPlayer1,
+    balanceKind: event.balanceKind,
   });
   useGameStore.setState({ matchStake: event.stake, matchBoostStake: event.boostStake });
-  store.setMatchFound(event.matchId, event.opponentName, event.opponentRating, event.isPlayer1);
+  store.setMatchFound(event.matchId, event.balanceKind, event.opponentName, event.opponentRating, event.isPlayer1);
   useGameStore.setState({
     currentRound: event.currentRound,
     myEnergy: event.myEnergy,
@@ -314,7 +319,7 @@ function applyMatchSettled(event: Extract<GameplayProviderEvent, { type: 'matchS
   const isDraw = event.winner === 'draw';
   const { winnerPayout, rake } = calculatePayout(event.stake, RAKE_PERCENT);
   const boostStake = store.matchBoostStake;
-  const currency = activeCurrency();
+  const currency = currencyForBalanceKind(event.balanceKind);
 
   let ratingDelta = 0;
   if (!isDraw) {
@@ -353,6 +358,7 @@ function applyMatchSettled(event: Extract<GameplayProviderEvent, { type: 'matchS
 
   store.setMatchResult({
     winner: event.winner,
+    balanceKind: event.balanceKind,
     myScore: event.myScore,
     opponentScore: event.opponentScore,
     elmEarned: isDraw ? 0 : won ? winnerPayout - event.stake + boostStake : -event.stake - boostStake,
@@ -440,9 +446,4 @@ function trace(event: string, data: Record<string, unknown>): void {
   recordGameLog('info', event, data);
   if (!TRACE_ENABLED) return;
   console.info(`[elmental:client] ${event}`, data);
-}
-
-function activeCurrency() {
-  const store = useGameStore.getState();
-  return currencyForUser(store.telegramUser ?? currentUser);
 }

--- a/apps/tma/src/stores/gameStore.ts
+++ b/apps/tma/src/stores/gameStore.ts
@@ -33,6 +33,7 @@ export interface TelegramUser {
 
 export interface MatchResult {
   winner: 'me' | 'opponent' | 'draw';
+  balanceKind: string;
   myScore: number;
   opponentScore: number;
   elmEarned: number;
@@ -114,6 +115,7 @@ interface GameStore {
 
   // Match state
   matchId: string | null;
+  matchBalanceKind: string;
   isPlayer1: boolean;
   matchStatus: MatchStatus;
   opponentName: string;
@@ -137,6 +139,7 @@ interface GameStore {
   cancelMatchmaking: () => void;
   setMatchFound: (
     matchId: string,
+    balanceKind: string,
     opponentName: string,
     opponentRating: number,
     isPlayer1?: boolean,
@@ -197,6 +200,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   // Match state
   matchId: null,
+  matchBalanceKind: 'demo_teml',
   isPlayer1: true,
   matchStatus: 'idle',
   opponentName: '',
@@ -223,9 +227,10 @@ export const useGameStore = create<GameStore>((set, get) => ({
   cancelMatchmaking: () =>
     set({ matchStatus: 'idle', currentScreen: 'home' }),
 
-  setMatchFound: (matchId, opponentName, opponentRating, isPlayer1 = true) =>
+  setMatchFound: (matchId, balanceKind, opponentName, opponentRating, isPlayer1 = true) =>
     set({
       matchId,
+      matchBalanceKind: balanceKind,
       isPlayer1,
       opponentName,
       opponentRating,
@@ -296,6 +301,7 @@ export const useGameStore = create<GameStore>((set, get) => ({
   resetMatch: () =>
     set({
       matchId: null,
+      matchBalanceKind: 'demo_teml',
       isPlayer1: true,
       matchStatus: 'idle',
       opponentName: '',


### PR DESCRIPTION
## Summary

- Carry `balanceKind` through player stats, queue, match, round, and settlement provider events.
- Store the active match balance kind and include it in bug report snapshots.
- Use match balance kind, not only user source, when rendering result economy currency.
- Extend mock and Spacetime provider contract tests for `paid_elm`/`demo_teml` balance domains.

## Validation

- `spacetime build --module-path apps/spacetime/spacetimedb`
- `pnpm --filter @elmental/tma test -- run`
- `pnpm --filter @elmental/tma build`
- `pnpm test:matrix-parity`

Closes #36.

Stacked on #46.
