### PR TITLE
[codex] Add wallet payment history

### DIFF
--- a/apps/payments/README.md
+++ b/apps/payments/README.md
@@ -9,6 +9,7 @@ Small Telegram Stars payment service for the Telegram Mini App. It is separate f
 - `POST /payments/stars/invoice`
 - `POST /payments/stars/refund/quote`
 - `POST /payments/stars/refund`
+- `POST /payments/wallet/history`
 - `POST /telegram/webhook`
 
 ## Required Environment
@@ -36,3 +37,18 @@ Without `PAYMENTS_SPACETIME_TOKEN`, successful payments are validated and logged
 Refunds are intentionally whole-lot only. Telegram's Bot API refunds by original
 `telegram_payment_charge_id`, not by arbitrary partial Star amount, so a partially
 spent purchase lot is not refundable.
+
+## Operator Ledger Queries
+
+`payment_ledger` is private to SpacetimeDB clients, but operators can query it through
+SpacetimeDB SQL when debugging payments:
+
+```bash
+spacetime sql --server maincloud elmental-v2 "SELECT payment_id, account_id, telegram_user_id, stars_amount, elm_amount, status, created_at_micros, updated_at_micros FROM payment_ledger WHERE telegram_user_id = '123456789'"
+spacetime sql --server maincloud elmental-v2 "SELECT payment_id, account_id, telegram_user_id, stars_amount, elm_amount, status, created_at_micros, updated_at_micros FROM payment_ledger WHERE account_id = 'telegram:123456789'"
+spacetime sql --server maincloud elmental-v2 "SELECT payment_id, account_id, telegram_user_id, stars_amount, elm_amount, status, created_at_micros, updated_at_micros FROM payment_ledger WHERE payment_id = 'purchase_id'"
+spacetime sql --server maincloud elmental-v2 "SELECT payment_id, account_id, telegram_user_id, stars_amount, elm_amount, status, created_at_micros, updated_at_micros FROM payment_ledger WHERE telegram_payment_charge_id = 'telegram_charge_id'"
+```
+
+Do not paste bot tokens, raw WebApp init data, invoice payloads, or charge IDs into
+client-side bug reports.

--- a/apps/payments/src/index.ts
+++ b/apps/payments/src/index.ts
@@ -3,6 +3,7 @@ import { createPaymentsServer } from './server.js';
 import { createSpacetimePaymentRecorder } from './spacetimeRecorder.js';
 import { createStarsRefundService } from './starsRefunds.js';
 import { createTelegramBotApi } from './telegramBotApi.js';
+import { createWalletHistoryService } from './walletHistory.js';
 
 const config = loadConfig();
 const telegram = createTelegramBotApi(config.botToken, config.botApiBaseUrl);
@@ -12,10 +13,13 @@ const paymentRecorder = config.spacetime
 const refundService = config.spacetime
   ? createStarsRefundService(config.spacetime, telegram)
   : undefined;
+const walletHistoryService = config.spacetime
+  ? createWalletHistoryService(config.spacetime)
+  : undefined;
 if (!paymentRecorder) {
-  console.warn('[payments] PAYMENTS_SPACETIME_TOKEN is not set; successful payments will be logged but not credited and refunds are disabled');
+  console.warn('[payments] PAYMENTS_SPACETIME_TOKEN is not set; successful payments will be logged but not credited, wallet history and refunds are disabled');
 }
-const server = createPaymentsServer({ config, telegram, paymentRecorder, refundService });
+const server = createPaymentsServer({ config, telegram, paymentRecorder, refundService, walletHistoryService });
 
 server.listen(config.port, () => {
   console.log(`[payments] Service listening on port ${config.port}`);
@@ -25,6 +29,7 @@ function shutdown(): void {
   console.log('[payments] Shutting down...');
   paymentRecorder?.dispose?.();
   refundService?.dispose?.();
+  walletHistoryService?.dispose?.();
   server.close(() => {
     process.exit(0);
   });

--- a/apps/payments/src/server.test.ts
+++ b/apps/payments/src/server.test.ts
@@ -7,6 +7,7 @@ import { createPaymentsServer } from './server.js';
 import type { StarsRefundService } from './starsRefunds.js';
 import type { TelegramBotApi } from './telegramBotApi.js';
 import type { PaymentEventRecorder } from './telegramUpdates.js';
+import type { WalletHistoryService } from './walletHistory.js';
 
 const botToken = '123456:test_bot_token';
 const config = loadConfig({
@@ -199,14 +200,64 @@ describe('payments server', () => {
       starsAmount: 1,
     });
   });
+
+  it('returns sanitized wallet history for Telegram users', async () => {
+    const telegram = createTelegramMock();
+    const walletHistoryService: WalletHistoryService = {
+      history: vi.fn(async () => ({
+        accountId: 'telegram:99',
+        telegramUserId: '99',
+        entries: [{
+          id: 'payment:purchase_1:credit',
+          kind: 'elm_credit' as const,
+          status: 'settled' as const,
+          title: 'ELM credited',
+          description: '100 ELM credited from Stars purchase',
+          occurredAt: '2026-05-17T00:00:00.000Z',
+          balanceKind: 'paid_elm',
+          elmAmount: 100,
+          starsAmount: 1,
+          paymentId: 'purchase_1',
+        }],
+        summary: {
+          totalStarsPurchased: 1,
+          totalElmCredited: 100,
+          totalStarsRefunded: 0,
+          totalElmRefunded: 0,
+          pendingRefundStars: 0,
+          pvpNetElm: 0,
+        },
+      })),
+    };
+    const baseUrl = await listen(telegram, undefined, undefined, walletHistoryService);
+
+    const response = await fetch(`${baseUrl}/payments/wallet/history`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ initData: signedInitData({ id: 99, first_name: 'Buyer' }) }),
+    });
+
+    expect(response.status).toBe(200);
+    const body = await response.json() as Record<string, unknown>;
+    expect(body['entries']).toEqual([expect.objectContaining({
+      kind: 'elm_credit',
+      paymentId: 'purchase_1',
+    })]);
+    expect(JSON.stringify(body)).not.toContain('telegramPaymentChargeId');
+    expect(walletHistoryService.history).toHaveBeenCalledWith({
+      accountId: 'telegram:99',
+      telegramUserId: '99',
+    });
+  });
 });
 
 async function listen(
   telegram: TelegramBotApi,
   paymentRecorder?: PaymentEventRecorder,
   refundService?: StarsRefundService,
+  walletHistoryService?: WalletHistoryService,
 ): Promise<string> {
-  server = createPaymentsServer({ config, telegram, paymentRecorder, refundService });
+  server = createPaymentsServer({ config, telegram, paymentRecorder, refundService, walletHistoryService });
   await new Promise<void>(resolve => server?.listen(0, resolve));
   const address = server.address();
   if (!address || typeof address === 'string') throw new Error('Server did not listen on a TCP port');

--- a/apps/payments/src/server.ts
+++ b/apps/payments/src/server.ts
@@ -7,12 +7,14 @@ import type { PaymentsConfig } from './config.js';
 import type { StarsRefundService } from './starsRefunds.js';
 import type { TelegramBotApi } from './telegramBotApi.js';
 import type { PaymentEventRecorder } from './telegramUpdates.js';
+import type { WalletHistoryService } from './walletHistory.js';
 
 interface ServerDeps {
   config: PaymentsConfig;
   telegram: TelegramBotApi;
   paymentRecorder?: PaymentEventRecorder;
   refundService?: StarsRefundService;
+  walletHistoryService?: WalletHistoryService;
 }
 
 interface InvoiceRequestBody {
@@ -30,9 +32,10 @@ export function createPaymentsServer({
   telegram,
   paymentRecorder = noopPaymentEventRecorder,
   refundService,
+  walletHistoryService,
 }: ServerDeps): http.Server {
   return http.createServer((req, res) => {
-    void handleRequest(req, res, config, telegram, paymentRecorder, refundService).catch(err => {
+    void handleRequest(req, res, config, telegram, paymentRecorder, refundService, walletHistoryService).catch(err => {
       console.error('[payments] Request failed:', err);
       sendJson(res, 500, { error: 'Internal server error' });
     });
@@ -46,6 +49,7 @@ async function handleRequest(
   telegram: TelegramBotApi,
   paymentRecorder: PaymentEventRecorder,
   refundService?: StarsRefundService,
+  walletHistoryService?: WalletHistoryService,
 ): Promise<void> {
   setCors(req, res, config);
 
@@ -79,6 +83,11 @@ async function handleRequest(
 
   if (req.method === 'POST' && url.pathname === '/payments/stars/refund') {
     await handleRefund(req, res, config, refundService);
+    return;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/payments/wallet/history') {
+    await handleWalletHistory(req, res, config, walletHistoryService);
     return;
   }
 
@@ -136,11 +145,42 @@ async function handleRefund(
   const starsAmount = typeof body.starsAmount === 'number' ? body.starsAmount : 0;
   const telegramUserId = String(user.id);
   const accountId = `telegram:${telegramUserId}`;
+  console.log(`[payments] Stars refund requested account=${accountId} stars=${starsAmount}`);
   try {
     const result = await refundService.refund({ accountId, telegramUserId, starsAmount });
+    console.log(
+      `[payments] Stars refund completed account=${accountId} stars=${result.refundedStarsAmount} lots=${result.refundedLots.length}`,
+    );
     sendJson(res, 200, result);
   } catch (err) {
+    console.warn(
+      `[payments] Stars refund failed account=${accountId} stars=${starsAmount} error=${err instanceof Error ? err.message : String(err)}`,
+    );
     sendJson(res, 400, { error: err instanceof Error ? err.message : 'Refund failed' });
+  }
+}
+
+async function handleWalletHistory(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  config: PaymentsConfig,
+  walletHistoryService?: WalletHistoryService,
+): Promise<void> {
+  if (!walletHistoryService) {
+    sendJson(res, 503, { error: 'Wallet history service is not configured' });
+    return;
+  }
+
+  const user = await readTelegramUser(req, res, config);
+  if (!user) return;
+
+  const telegramUserId = String(user.id);
+  const accountId = `telegram:${telegramUserId}`;
+  try {
+    const history = await walletHistoryService.history({ accountId, telegramUserId });
+    sendJson(res, 200, history);
+  } catch (err) {
+    sendJson(res, 400, { error: err instanceof Error ? err.message : 'Wallet history failed' });
   }
 }
 

--- a/apps/payments/src/walletHistory.test.ts
+++ b/apps/payments/src/walletHistory.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createWalletHistoryService } from './walletHistory.js';
+import type { SpacetimeCreditConfig } from './config.js';
+
+const config: SpacetimeCreditConfig = {
+  uri: 'http://localhost:3000',
+  database: 'test',
+  token: 'token',
+};
+
+describe('wallet history service', () => {
+  it('returns sanitized payment credit and refund entries', async () => {
+    const service = createWalletHistoryService(config, async () => fakeConnection({
+      ledgerRows: [ledger({
+        status: 'refunded',
+        refundedStarsAmount: 1,
+        refundedElmAmount: 100,
+        refundRequestedAtMicros: 4_000_000n,
+        refundedAtMicros: 5_000_000n,
+      })],
+    }));
+
+    const history = await service.history({
+      accountId: 'telegram:99',
+      telegramUserId: '99',
+    });
+
+    expect(history.entries).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'stars_purchase', starsAmount: 1, elmAmount: 100 }),
+      expect.objectContaining({ kind: 'elm_credit', status: 'settled', elmAmount: 100 }),
+      expect.objectContaining({ kind: 'stars_refund', status: 'settled', elmAmount: -100 }),
+    ]));
+    expect(history.summary).toMatchObject({
+      totalStarsPurchased: 1,
+      totalElmCredited: 100,
+      totalStarsRefunded: 1,
+      totalElmRefunded: 100,
+    });
+    expect(JSON.stringify(history)).not.toContain('charge_');
+    expect(JSON.stringify(history)).not.toContain('invoicePayload');
+  });
+
+  it('includes paid ELM PvP stake, winnings, and boost return entries', async () => {
+    const service = createWalletHistoryService(config, async () => fakeConnection({
+      players: [player({ identity: identity('p1'), accountId: 'telegram:99' })],
+      matches: [match({
+        p1: identity('p1'),
+        p2: identity('p2'),
+        p1BoostEnabled: true,
+        winner: identity('p1'),
+      })],
+    }));
+
+    const history = await service.history({
+      accountId: 'telegram:99',
+      telegramUserId: '99',
+    });
+
+    expect(history.entries).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'pvp_stake', elmAmount: -100, matchId: '7' }),
+      expect.objectContaining({ kind: 'pvp_boost_stake', elmAmount: -10, matchId: '7' }),
+      expect.objectContaining({ kind: 'pvp_win', elmAmount: 190, matchId: '7' }),
+      expect.objectContaining({ kind: 'pvp_boost_return', elmAmount: 10, matchId: '7' }),
+    ]));
+    expect(history.summary.pvpNetElm).toBe(90);
+  });
+});
+
+function fakeConnection(input: {
+  ledgerRows?: ReturnType<typeof ledger>[];
+  players?: ReturnType<typeof player>[];
+  matches?: ReturnType<typeof match>[];
+}) {
+  return {
+    db: {
+      account: { iter: () => [] },
+      paymentLedger: { iter: () => input.ledgerRows ?? [] },
+      player: { iter: () => input.players ?? [] },
+      matchState: { iter: () => input.matches ?? [] },
+    },
+    disconnect: vi.fn(),
+  };
+}
+
+function ledger(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    paymentId: 'purchase_1',
+    accountId: 'telegram:99',
+    telegramUserId: '99',
+    starsAmount: 1,
+    elmAmount: 100,
+    refundableElmAmount: 100,
+    refundedStarsAmount: 0,
+    refundedElmAmount: 0,
+    telegramPaymentChargeId: 'charge_secret',
+    invoicePayload: 'signed_payload_secret',
+    balanceKind: 'paid_elm',
+    status: 'credited',
+    createdAtMicros: 1_000_000n,
+    paidAtMicros: 2_000_000n,
+    creditedAtMicros: 3_000_000n,
+    refundRequestedAtMicros: undefined,
+    refundedAtMicros: undefined,
+    updatedAtMicros: 3_000_000n,
+    ...overrides,
+  };
+}
+
+function player(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    identity: identity('p1'),
+    name: 'Player',
+    online: true,
+    rating: 1200,
+    wins: 0,
+    losses: 0,
+    balance: 1000,
+    balanceKind: 'paid_elm',
+    accountId: 'telegram:99',
+    ...overrides,
+  };
+}
+
+function match(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 7n,
+    p1: identity('p1'),
+    p2: identity('p2'),
+    p1Name: 'Player',
+    p2Name: 'Opponent',
+    p1Rating: 1200,
+    p2Rating: 1200,
+    stake: 100,
+    balanceKind: 'paid_elm',
+    mode: 'classic',
+    room: 'test',
+    phase: 'complete',
+    status: 'settled',
+    currentRound: 4,
+    p1Score: 3,
+    p2Score: 0,
+    p1Energy: 80,
+    p2Energy: 100,
+    p1BoostEnabled: false,
+    p2BoostEnabled: false,
+    p1CommitHash: undefined,
+    p2CommitHash: undefined,
+    p1RevealMove: undefined,
+    p2RevealMove: undefined,
+    p1RevealSalt: undefined,
+    p2RevealSalt: undefined,
+    winner: identity('p1'),
+    replayHash: undefined,
+    createdAtMicros: 10_000_000n,
+    updatedAtMicros: 20_000_000n,
+    roundStartedAtMicros: 10_000_000n,
+    nextRoundReadyAtMicros: undefined,
+    ...overrides,
+  };
+}
+
+function identity(value: string): any {
+  return {
+    toHexString: () => value,
+  };
+}

--- a/apps/payments/src/walletHistory.ts
+++ b/apps/payments/src/walletHistory.ts
@@ -1,0 +1,360 @@
+import { DbConnection } from './module_bindings/index.js';
+import type { SpacetimeCreditConfig } from './config.js';
+import type { MatchState, PaymentLedger, Player } from './module_bindings/types.js';
+
+const PAID_ELM_BALANCE_KIND = 'paid_elm';
+const PAYMENT_STATUS_CREDITED = 'credited';
+const PAYMENT_STATUS_REFUND_PENDING = 'refund_pending';
+const PAYMENT_STATUS_REFUNDED = 'refunded';
+const RAKE_PERCENT = 5;
+
+export type WalletHistoryEntryKind =
+  | 'stars_purchase'
+  | 'elm_credit'
+  | 'stars_refund'
+  | 'pvp_stake'
+  | 'pvp_boost_stake'
+  | 'pvp_win'
+  | 'pvp_draw_refund'
+  | 'pvp_boost_return';
+
+export type WalletHistoryStatus = 'settled' | 'pending' | 'failed';
+
+export interface WalletHistoryEntry {
+  id: string;
+  kind: WalletHistoryEntryKind;
+  status: WalletHistoryStatus;
+  title: string;
+  description: string;
+  occurredAt: string;
+  balanceKind: string;
+  elmAmount: number;
+  starsAmount?: number;
+  paymentId?: string;
+  matchId?: string;
+}
+
+export interface WalletHistorySummary {
+  totalStarsPurchased: number;
+  totalElmCredited: number;
+  totalStarsRefunded: number;
+  totalElmRefunded: number;
+  pendingRefundStars: number;
+  pvpNetElm: number;
+}
+
+export interface WalletHistoryResponse {
+  accountId: string;
+  telegramUserId: string;
+  entries: WalletHistoryEntry[];
+  summary: WalletHistorySummary;
+}
+
+export interface WalletHistoryService {
+  history(input: { accountId: string; telegramUserId: string }): Promise<WalletHistoryResponse>;
+  dispose?(): void;
+}
+
+interface HistoryConnection {
+  db: {
+    paymentLedger: { iter(): Iterable<PaymentLedger> };
+    player: { iter(): Iterable<Player> };
+    matchState: { iter(): Iterable<MatchState> };
+  };
+  disconnect(): void;
+}
+
+type ConnectHistory = (config: SpacetimeCreditConfig) => Promise<HistoryConnection>;
+
+export function createWalletHistoryService(
+  config: SpacetimeCreditConfig,
+  connect: ConnectHistory = connectHistory,
+): WalletHistoryService {
+  let connectionPromise: Promise<HistoryConnection> | null = null;
+  let connection: HistoryConnection | null = null;
+
+  async function getConnection(): Promise<HistoryConnection> {
+    if (connection) return connection;
+    connectionPromise ??= connect(config).then(conn => {
+      connection = conn;
+      return conn;
+    }).catch(err => {
+      connectionPromise = null;
+      throw err;
+    });
+    return connectionPromise;
+  }
+
+  return {
+    async history(input) {
+      const conn = await getConnection();
+      return buildWalletHistory(conn, input.accountId, input.telegramUserId);
+    },
+
+    dispose(): void {
+      connection?.disconnect();
+      connection = null;
+      connectionPromise = null;
+    },
+  };
+}
+
+function buildWalletHistory(
+  conn: HistoryConnection,
+  accountId: string,
+  telegramUserId: string,
+): WalletHistoryResponse {
+  const entries = [
+    ...paymentEntries(conn, accountId, telegramUserId),
+    ...pvpEntries(conn, accountId),
+  ].sort((a, b) => b.occurredAt.localeCompare(a.occurredAt)).slice(0, 80);
+
+  return {
+    accountId,
+    telegramUserId,
+    entries,
+    summary: summarize(entries),
+  };
+}
+
+function paymentEntries(conn: HistoryConnection, accountId: string, telegramUserId: string): WalletHistoryEntry[] {
+  const entries: WalletHistoryEntry[] = [];
+  const rows = [...conn.db.paymentLedger.iter()]
+    .filter(row => row.accountId === accountId && row.telegramUserId === telegramUserId)
+    .sort((a, b) => compareMicros(a.createdAtMicros, b.createdAtMicros));
+
+  for (const row of rows) {
+    const purchaseStatus = isCreditedStatus(row.status) ? 'settled' : 'failed';
+    const paidAt = toIso(row.paidAtMicros ?? row.createdAtMicros);
+    entries.push({
+      id: `payment:${row.paymentId}:purchase`,
+      kind: 'stars_purchase',
+      status: purchaseStatus,
+      title: 'Stars purchase',
+      description: `${row.starsAmount} Stars for ${row.elmAmount} ELM`,
+      occurredAt: paidAt,
+      balanceKind: row.balanceKind,
+      elmAmount: row.elmAmount,
+      starsAmount: row.starsAmount,
+      paymentId: row.paymentId,
+    });
+
+    if (row.creditedAtMicros !== undefined) {
+      entries.push({
+        id: `payment:${row.paymentId}:credit`,
+        kind: 'elm_credit',
+        status: purchaseStatus,
+        title: 'ELM credited',
+        description: `${row.elmAmount} ELM credited from Stars purchase`,
+        occurredAt: toIso(row.creditedAtMicros),
+        balanceKind: row.balanceKind,
+        elmAmount: row.elmAmount,
+        starsAmount: row.starsAmount,
+        paymentId: row.paymentId,
+      });
+    }
+
+    if (row.refundRequestedAtMicros !== undefined || row.refundedAtMicros !== undefined) {
+      const refunded = row.status === PAYMENT_STATUS_REFUNDED && row.refundedAtMicros !== undefined;
+      const starsAmount = refunded ? row.refundedStarsAmount : row.starsAmount;
+      const elmAmount = refunded ? row.refundedElmAmount : row.elmAmount;
+      entries.push({
+        id: `payment:${row.paymentId}:refund`,
+        kind: 'stars_refund',
+        status: refunded ? 'settled' : row.status === PAYMENT_STATUS_REFUND_PENDING ? 'pending' : 'failed',
+        title: refunded ? 'Stars refunded' : 'Stars refund pending',
+        description: `${elmAmount} ELM for ${starsAmount} Stars`,
+        occurredAt: toIso(row.refundedAtMicros ?? row.refundRequestedAtMicros ?? row.updatedAtMicros),
+        balanceKind: row.balanceKind,
+        elmAmount: -elmAmount,
+        starsAmount,
+        paymentId: row.paymentId,
+      });
+    }
+  }
+  return entries;
+}
+
+function pvpEntries(conn: HistoryConnection, accountId: string): WalletHistoryEntry[] {
+  const identitySet = new Set(
+    [...conn.db.player.iter()]
+      .filter(row => row.accountId === accountId)
+      .map(row => identityHex(row.identity)),
+  );
+  if (identitySet.size === 0) return [];
+
+  const entries: WalletHistoryEntry[] = [];
+  for (const row of conn.db.matchState.iter()) {
+    if (row.status !== 'settled' || row.balanceKind !== PAID_ELM_BALANCE_KIND) continue;
+    const p1 = identityHex(row.p1);
+    const p2 = identityHex(row.p2);
+    const side = identitySet.has(p1) ? 'p1' : identitySet.has(p2) ? 'p2' : null;
+    if (!side) continue;
+
+    const matchId = row.id.toString();
+    const boostEnabled = side === 'p1' ? row.p1BoostEnabled : row.p2BoostEnabled;
+    const boostStake = boostEnabled ? Math.ceil(row.stake * 0.1) : 0;
+    const opponentName = side === 'p1' ? row.p2Name : row.p1Name;
+    const settledAt = toIso(row.updatedAtMicros);
+    entries.push({
+      id: `match:${matchId}:stake`,
+      kind: 'pvp_stake',
+      status: 'settled',
+      title: 'PvP stake',
+      description: `Match vs ${opponentName}`,
+      occurredAt: toIso(row.createdAtMicros),
+      balanceKind: row.balanceKind,
+      elmAmount: -row.stake,
+      matchId,
+    });
+    if (boostStake > 0) {
+      entries.push({
+        id: `match:${matchId}:boost_stake`,
+        kind: 'pvp_boost_stake',
+        status: 'settled',
+        title: 'Energy Boost stake',
+        description: `Match vs ${opponentName}`,
+        occurredAt: toIso(row.createdAtMicros),
+        balanceKind: row.balanceKind,
+        elmAmount: -boostStake,
+        matchId,
+      });
+    }
+
+    if (row.winner === undefined) {
+      entries.push({
+        id: `match:${matchId}:draw_refund`,
+        kind: 'pvp_draw_refund',
+        status: 'settled',
+        title: 'Draw refund',
+        description: `Match vs ${opponentName}`,
+        occurredAt: settledAt,
+        balanceKind: row.balanceKind,
+        elmAmount: row.stake,
+        matchId,
+      });
+      if (boostStake > 0) entries.push(boostReturnEntry(matchId, opponentName, boostStake, settledAt, row.balanceKind));
+      continue;
+    }
+
+    const won = identityHex(row.winner) === (side === 'p1' ? p1 : p2);
+    if (won) {
+      entries.push({
+        id: `match:${matchId}:win`,
+        kind: 'pvp_win',
+        status: 'settled',
+        title: 'PvP winnings',
+        description: `Match vs ${opponentName}`,
+        occurredAt: settledAt,
+        balanceKind: row.balanceKind,
+        elmAmount: winnerPayout(row.stake),
+        matchId,
+      });
+      if (boostStake > 0) entries.push(boostReturnEntry(matchId, opponentName, boostStake, settledAt, row.balanceKind));
+    }
+  }
+  return entries;
+}
+
+function boostReturnEntry(
+  matchId: string,
+  opponentName: string,
+  amount: number,
+  occurredAt: string,
+  balanceKind: string,
+): WalletHistoryEntry {
+  return {
+    id: `match:${matchId}:boost_return`,
+    kind: 'pvp_boost_return',
+    status: 'settled',
+    title: 'Energy Boost returned',
+    description: `Match vs ${opponentName}`,
+    occurredAt,
+    balanceKind,
+    elmAmount: amount,
+    matchId,
+  };
+}
+
+function summarize(entries: WalletHistoryEntry[]): WalletHistorySummary {
+  return entries.reduce<WalletHistorySummary>((summary, entry) => {
+    if (entry.kind === 'stars_purchase') summary.totalStarsPurchased += entry.starsAmount ?? 0;
+    if (entry.kind === 'elm_credit') summary.totalElmCredited += Math.max(0, entry.elmAmount);
+    if (entry.kind === 'stars_refund' && entry.status === 'settled') {
+      summary.totalStarsRefunded += entry.starsAmount ?? 0;
+      summary.totalElmRefunded += Math.abs(entry.elmAmount);
+    }
+    if (entry.kind === 'stars_refund' && entry.status === 'pending') {
+      summary.pendingRefundStars += entry.starsAmount ?? 0;
+    }
+    if (entry.kind.startsWith('pvp_')) summary.pvpNetElm += entry.elmAmount;
+    return summary;
+  }, {
+    totalStarsPurchased: 0,
+    totalElmCredited: 0,
+    totalStarsRefunded: 0,
+    totalElmRefunded: 0,
+    pendingRefundStars: 0,
+    pvpNetElm: 0,
+  });
+}
+
+function isCreditedStatus(status: string): boolean {
+  return status === PAYMENT_STATUS_CREDITED ||
+    status === PAYMENT_STATUS_REFUND_PENDING ||
+    status === PAYMENT_STATUS_REFUNDED;
+}
+
+function winnerPayout(stake: number): number {
+  const pool = stake * 2;
+  return pool - Math.floor((pool * RAKE_PERCENT) / 100);
+}
+
+function identityHex(identity: { toHexString(): string }): string {
+  return identity.toHexString();
+}
+
+function compareMicros(a: bigint, b: bigint): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function toIso(micros: bigint): string {
+  return new Date(Number(micros / 1000n)).toISOString();
+}
+
+function connectHistory(config: SpacetimeCreditConfig): Promise<HistoryConnection> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const connection = DbConnection.builder()
+      .withUri(config.uri)
+      .withDatabaseName(config.database)
+      .withToken(config.token)
+      .withCompression('none')
+      .onConnect((conn, identity) => {
+        console.log(`[payments] Connected wallet history service to SpacetimeDB as ${identity.toHexString()}`);
+        conn.subscriptionBuilder()
+          .onApplied(() => {
+            settled = true;
+            resolve(conn);
+          })
+          .onError((ctx) => {
+            if (!settled) reject(new Error(`Wallet history subscription failed: ${String(ctx)}`));
+          })
+          .subscribeToAllTables();
+      })
+      .onConnectError((_ctx, err) => {
+        if (!settled) reject(err);
+      })
+      .onDisconnect((_ctx, err) => {
+        if (err) console.error('[payments] Wallet history SpacetimeDB disconnected:', err.message);
+      })
+      .build();
+
+    setTimeout(() => {
+      if (!settled) {
+        connection.disconnect();
+        reject(new Error('Timed out connecting wallet history service to SpacetimeDB'));
+      }
+    }, 10_000).unref();
+  });
+}

--- a/apps/tma/src/screens/ProfileScreen.tsx
+++ b/apps/tma/src/screens/ProfileScreen.tsx
@@ -5,7 +5,14 @@ import { updatePlayerProfile } from '../services/gameService';
 import { haptic, sanitizeWebUserName, saveWebUser } from '../services/telegram';
 import { playerDisplayName, playerFullName } from '../services/playerProfile';
 import { opponentWinRate } from '../services/opponentStats';
-import { currencyForUser, formatCurrencyAmount } from '../services/economy';
+import { currencyForUser, formatCurrencyAmount, type EconomyCurrency } from '../services/economy';
+import {
+  requestWalletHistory,
+  type WalletHistoryEntry,
+  type WalletHistoryEntryKind,
+  type WalletHistoryStatus,
+} from '../services/payments';
+import type { EconomyTransaction } from '../stores/gameStore';
 import { ArrowLeftIcon } from '../components/icons/ArrowLeftIcon';
 import { StarIcon } from '../components/icons/StarIcon';
 import { CheckIcon } from '../components/icons/CheckIcon';
@@ -16,7 +23,19 @@ import { FlameIcon } from '../components/icons/FlameIcon';
 import { SwordsIcon } from '../components/icons/SwordsIcon';
 
 export function ProfileScreen() {
-  const { telegramUser, rating, stats, opponentStats, elmBalance, setScreen, setTelegramUser, transactions } = useGameStore();
+  const {
+    telegramUser,
+    rating,
+    stats,
+    opponentStats,
+    elmBalance,
+    setScreen,
+    setTelegramUser,
+    transactions,
+    walletHistory,
+    walletHistoryStatus,
+    setWalletHistory,
+  } = useGameStore();
 
   const displayName = playerDisplayName(telegramUser);
   const profileSubtitle = telegramUser?.source === 'telegram' && telegramUser.username
@@ -31,11 +50,42 @@ export function ProfileScreen() {
   const cleanDraftName = useMemo(() => sanitizeWebUserName(draftName), [draftName]);
   const canSaveWebName =
     isWebUser && cleanDraftName.length > 0 && cleanDraftName !== displayName && saveStatus !== 'saving';
+  const historyItems = useMemo(
+    () => buildHistoryItems(walletHistory, transactions),
+    [walletHistory, transactions],
+  );
 
   useEffect(() => {
     setDraftName(displayName);
     setSaveStatus('idle');
   }, [displayName]);
+
+  useEffect(() => {
+    if (telegramUser?.source !== 'telegram') {
+      setWalletHistory([], null, 'idle');
+      return;
+    }
+
+    const initData = telegramUser.initData ?? '';
+    if (!initData) {
+      setWalletHistory([], null, 'failed');
+      return;
+    }
+
+    let cancelled = false;
+    setWalletHistory([], null, 'loading');
+    void requestWalletHistory({ initData }).then((history) => {
+      if (cancelled) return;
+      setWalletHistory(history.entries, history.summary, 'ready');
+    }).catch(() => {
+      if (cancelled) return;
+      setWalletHistory([], null, 'failed');
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [telegramUser?.id, telegramUser?.initData, telegramUser?.source, setWalletHistory]);
 
   const winRate =
     stats.wins + stats.losses > 0
@@ -314,47 +364,56 @@ export function ProfileScreen() {
           )}
         </motion.div>
 
-        {/* Transaction History */}
+        {/* Wallet History */}
         <motion.div
           className="glass-card p-4"
           initial={{ opacity: 0, y: 10 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.15 }}
         >
-          <div className="text-xs text-text-secondary font-semibold tracking-widest uppercase mb-3">
-            Transaction History
+          <div className="flex items-center justify-between gap-3 mb-3">
+            <div className="text-xs text-text-secondary font-semibold tracking-widest uppercase">
+              Wallet History
+            </div>
+            {walletHistoryStatus === 'loading' ? (
+              <div className="text-[10px] font-bold uppercase tracking-widest text-text-muted">Syncing</div>
+            ) : walletHistoryStatus === 'failed' && telegramUser?.source === 'telegram' ? (
+              <div className="text-[10px] font-bold uppercase tracking-widest text-energy-low">Offline</div>
+            ) : null}
           </div>
-          {transactions.length === 0 ? (
+          {historyItems.length === 0 ? (
             <div className="text-center py-6">
               <div className="flex justify-center mb-2">
                 <ControllerIcon size={32} className="text-text-muted" />
               </div>
-              <div className="text-sm text-text-muted">No transactions yet</div>
+              <div className="text-sm text-text-muted">No wallet activity yet</div>
               <div className="text-xs text-text-muted mt-1">Play your first match!</div>
             </div>
           ) : (
-            <div className="flex flex-col gap-1.5">
-              {transactions.slice(0, 20).map((tx) => {
-                const icon = tx.type === 'win' ? <CoinsIcon size={16} className="text-energy-high" /> :
-                             tx.type === 'loss' ? <CoinsIcon size={16} className="text-energy-low" /> :
-                             tx.type === 'stake' ? <CrossIcon size={16} className="text-text-secondary" /> :
-                             tx.type === 'boost_burn' ? <FlameIcon size={16} className="text-energy-low" /> :
-                             tx.type === 'boost_return' ? <CheckIcon size={16} className="text-energy-high" /> :
-                             tx.type === 'rake' ? <CoinsIcon size={16} className="text-gold" /> :
-                             <CoinsIcon size={16} className="text-text-muted" />;
-                const color = tx.amount > 0 ? '#22c55e' : tx.amount < 0 ? '#ef4444' : '#8b949e';
+            <div className="flex flex-col gap-2">
+              {historyItems.slice(0, 30).map((item) => {
+                const color = item.elmAmount > 0 ? '#22c55e' : item.elmAmount < 0 ? '#ef4444' : '#8b949e';
                 return (
                   <div
-                    key={tx.id}
-                    className="flex items-center justify-between py-2 px-3 rounded-xl text-sm"
+                    key={item.id}
+                    className="flex items-center justify-between gap-3 py-2.5 px-3 rounded-xl text-sm"
                     style={{ background: 'rgba(255,255,255,0.03)' }}
                   >
                     <div className="flex items-center gap-2 flex-1 min-w-0">
-                      <span className="flex-shrink-0">{icon}</span>
-                      <span className="text-text-secondary text-xs truncate">{tx.description}</span>
+                      <span className="flex-shrink-0">{historyIcon(item)}</span>
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <span className="text-text-primary text-xs font-bold truncate">{item.title}</span>
+                          <span className={`text-[9px] font-black uppercase tracking-widest ${historyStatusClass(item.status)}`}>
+                            {item.status}
+                          </span>
+                        </div>
+                        <div className="text-text-secondary text-[11px] truncate">{item.description}</div>
+                        <div className="text-text-muted text-[10px]">{formatHistoryTime(item.occurredAt)}</div>
+                      </div>
                     </div>
                     <span className="font-bold text-xs ml-2 flex-shrink-0" style={{ color }}>
-                      {tx.amount !== 0 ? formatCurrencyAmount(tx.amount, currency, { signed: true }) : '—'}
+                      {historyAmountLabel(item, currency)}
                     </span>
                   </div>
                 );
@@ -380,4 +439,120 @@ export function ProfileScreen() {
       </div>
     </div>
   );
+}
+
+interface HistoryDisplayItem {
+  id: string;
+  kind: WalletHistoryEntryKind | EconomyTransaction['type'];
+  status: WalletHistoryStatus;
+  title: string;
+  description: string;
+  occurredAt: string;
+  elmAmount: number;
+  starsAmount?: number;
+  matchId?: string;
+}
+
+function buildHistoryItems(
+  walletHistory: WalletHistoryEntry[],
+  transactions: EconomyTransaction[],
+): HistoryDisplayItem[] {
+  const walletMatchIds = new Set(
+    walletHistory
+      .filter(entry => entry.matchId && entry.kind.startsWith('pvp_'))
+      .map(entry => entry.matchId),
+  );
+  const localItems = transactions
+    .filter(tx => !walletMatchIds.has(tx.matchId))
+    .map(transactionToHistoryItem);
+
+  return [
+    ...walletHistory.map(walletEntryToHistoryItem),
+    ...localItems,
+  ].sort((a, b) => b.occurredAt.localeCompare(a.occurredAt));
+}
+
+function walletEntryToHistoryItem(entry: WalletHistoryEntry): HistoryDisplayItem {
+  return {
+    id: entry.id,
+    kind: entry.kind,
+    status: entry.status,
+    title: entry.title,
+    description: entry.description,
+    occurredAt: entry.occurredAt,
+    elmAmount: entry.elmAmount,
+    starsAmount: entry.starsAmount,
+    matchId: entry.matchId,
+  };
+}
+
+function transactionToHistoryItem(tx: EconomyTransaction): HistoryDisplayItem {
+  return {
+    id: tx.id,
+    kind: tx.type,
+    status: 'settled',
+    title: transactionTitle(tx.type),
+    description: tx.description,
+    occurredAt: new Date(tx.timestamp).toISOString(),
+    elmAmount: tx.amount,
+    matchId: tx.matchId,
+  };
+}
+
+function transactionTitle(type: EconomyTransaction['type']): string {
+  switch (type) {
+    case 'stake':
+      return 'PvP stake';
+    case 'win':
+      return 'PvP result';
+    case 'loss':
+      return 'PvP loss';
+    case 'boost_burn':
+      return 'Energy Boost burned';
+    case 'boost_return':
+      return 'Energy Boost returned';
+    case 'rake':
+      return 'Rake';
+  }
+}
+
+function historyIcon(item: HistoryDisplayItem): React.ReactNode {
+  if (item.kind === 'stars_purchase') return <StarIcon size={16} className="text-gold" />;
+  if (item.kind === 'stars_refund') return <StarIcon size={16} className={item.status === 'pending' ? 'text-text-muted' : 'text-energy-high'} />;
+  if (item.kind === 'elm_credit' || item.kind === 'pvp_win' || item.kind === 'pvp_draw_refund') {
+    return <CoinsIcon size={16} className="text-energy-high" />;
+  }
+  if (item.kind === 'pvp_boost_stake' || item.kind === 'boost_burn') return <FlameIcon size={16} className="text-energy-low" />;
+  if (item.kind === 'pvp_boost_return' || item.kind === 'boost_return') return <CheckIcon size={16} className="text-energy-high" />;
+  if (item.elmAmount < 0) return <CrossIcon size={16} className="text-energy-low" />;
+  return <CoinsIcon size={16} className="text-text-muted" />;
+}
+
+function historyStatusClass(status: WalletHistoryStatus): string {
+  switch (status) {
+    case 'settled':
+      return 'text-energy-high';
+    case 'pending':
+      return 'text-gold';
+    case 'failed':
+      return 'text-energy-low';
+  }
+}
+
+function historyAmountLabel(item: HistoryDisplayItem, currency: EconomyCurrency): string {
+  if (item.kind === 'stars_purchase') return `${item.starsAmount ?? 0}★`;
+  if (item.kind === 'stars_refund') return `+${item.starsAmount ?? 0}★`;
+  if (item.elmAmount === 0) return '—';
+  return formatCurrencyAmount(item.elmAmount, currency, { signed: true });
+}
+
+function formatHistoryTime(value: string): string {
+  const time = new Date(value);
+  if (Number.isNaN(time.getTime())) return '';
+  return time.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
 }

--- a/apps/tma/src/services/bugReport.ts
+++ b/apps/tma/src/services/bugReport.ts
@@ -202,6 +202,19 @@ function gameSnapshot(): Record<string, unknown> {
       balanceKind,
       matchBalanceKind: state.matchBalanceKind,
       balance: state.elmBalance,
+      walletHistory: {
+        status: state.walletHistoryStatus,
+        summary: state.walletHistorySummary,
+        recent: state.walletHistory.slice(0, 8).map(entry => ({
+          kind: entry.kind,
+          status: entry.status,
+          elmAmount: entry.elmAmount,
+          starsAmount: entry.starsAmount,
+          paymentId: entry.paymentId,
+          matchId: entry.matchId,
+          occurredAt: entry.occurredAt,
+        })),
+      },
     },
     user: state.telegramUser
       ? {

--- a/apps/tma/src/services/payments.test.ts
+++ b/apps/tma/src/services/payments.test.ts
@@ -4,6 +4,7 @@ import {
   requestStarsRefund,
   requestStarsRefundQuote,
   requestStarsInvoice,
+  requestWalletHistory,
 } from './payments';
 
 describe('TMA Stars payments', () => {
@@ -131,6 +132,50 @@ describe('TMA Stars payments', () => {
     expect(fetchImpl).toHaveBeenCalledWith('https://payments.example.test/payments/stars/refund', expect.objectContaining({
       method: 'POST',
       body: JSON.stringify({ initData: 'signed-init-data', starsAmount: 1 }),
+    }));
+  });
+
+  it('requests sanitized wallet history from the payment service', async () => {
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      accountId: 'telegram:123',
+      telegramUserId: '123',
+      entries: [{
+        id: 'payment:purchase_1:credit',
+        kind: 'elm_credit',
+        status: 'settled',
+        title: 'ELM credited',
+        description: '100 ELM credited from Stars purchase',
+        occurredAt: '2026-05-17T00:00:00.000Z',
+        balanceKind: 'paid_elm',
+        elmAmount: 100,
+        starsAmount: 1,
+        paymentId: 'purchase_1',
+      }],
+      summary: {
+        totalStarsPurchased: 1,
+        totalElmCredited: 100,
+        totalStarsRefunded: 0,
+        totalElmRefunded: 0,
+        pendingRefundStars: 0,
+        pvpNetElm: 0,
+      },
+    }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as unknown as typeof fetch;
+
+    await expect(requestWalletHistory({
+      initData: 'signed-init-data',
+      paymentsUrl: 'https://payments.example.test',
+      fetchImpl,
+    })).resolves.toMatchObject({
+      summary: { totalElmCredited: 100 },
+      entries: [expect.objectContaining({ kind: 'elm_credit' })],
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith('https://payments.example.test/payments/wallet/history', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify({ initData: 'signed-init-data' }),
     }));
   });
 });

--- a/apps/tma/src/services/payments.ts
+++ b/apps/tma/src/services/payments.ts
@@ -41,6 +41,48 @@ export interface StarsRefundResult {
   refundedLots: StarsRefundLot[];
 }
 
+export type WalletHistoryEntryKind =
+  | 'stars_purchase'
+  | 'elm_credit'
+  | 'stars_refund'
+  | 'pvp_stake'
+  | 'pvp_boost_stake'
+  | 'pvp_win'
+  | 'pvp_draw_refund'
+  | 'pvp_boost_return';
+
+export type WalletHistoryStatus = 'settled' | 'pending' | 'failed';
+
+export interface WalletHistoryEntry {
+  id: string;
+  kind: WalletHistoryEntryKind;
+  status: WalletHistoryStatus;
+  title: string;
+  description: string;
+  occurredAt: string;
+  balanceKind: string;
+  elmAmount: number;
+  starsAmount?: number;
+  paymentId?: string;
+  matchId?: string;
+}
+
+export interface WalletHistorySummary {
+  totalStarsPurchased: number;
+  totalElmCredited: number;
+  totalStarsRefunded: number;
+  totalElmRefunded: number;
+  pendingRefundStars: number;
+  pvpNetElm: number;
+}
+
+export interface WalletHistoryResponse {
+  accountId: string;
+  telegramUserId: string;
+  entries: WalletHistoryEntry[];
+  summary: WalletHistorySummary;
+}
+
 export type TelegramInvoiceStatus = 'paid' | 'cancelled' | 'failed' | 'pending' | 'unknown';
 
 interface RequestStarsInvoiceInput {
@@ -123,6 +165,15 @@ export async function requestStarsRefund(input: RequestStarsRefundInput): Promis
     paymentsUrl: input.paymentsUrl,
     fetchImpl: input.fetchImpl,
     body: { starsAmount: input.starsAmount },
+  });
+}
+
+export async function requestWalletHistory(input: Omit<RequestStarsRefundInput, 'starsAmount'>): Promise<WalletHistoryResponse> {
+  return requestPaymentsJson<WalletHistoryResponse>({
+    path: '/payments/wallet/history',
+    initData: input.initData,
+    paymentsUrl: input.paymentsUrl,
+    fetchImpl: input.fetchImpl,
   });
 }
 

--- a/apps/tma/src/stores/gameStore.ts
+++ b/apps/tma/src/stores/gameStore.ts
@@ -8,6 +8,7 @@ import {
   type OpponentMatchOutcome,
   type OpponentStats,
 } from '../services/opponentStats';
+import type { WalletHistoryEntry, WalletHistorySummary } from '../services/payments';
 
 export type Screen =
   | 'home'
@@ -109,9 +110,17 @@ interface GameStore {
 
   // Economy
   transactions: EconomyTransaction[];
+  walletHistory: WalletHistoryEntry[];
+  walletHistorySummary: WalletHistorySummary | null;
+  walletHistoryStatus: 'idle' | 'loading' | 'ready' | 'failed';
   matchStake: number;
   matchBoostStake: number;
   addTransaction: (tx: EconomyTransaction) => void;
+  setWalletHistory: (
+    entries: WalletHistoryEntry[],
+    summary: WalletHistorySummary | null,
+    status: 'idle' | 'loading' | 'ready' | 'failed',
+  ) => void;
 
   // Match state
   matchId: string | null;
@@ -194,9 +203,17 @@ export const useGameStore = create<GameStore>((set, get) => ({
 
   // Economy
   transactions: [],
+  walletHistory: [],
+  walletHistorySummary: null,
+  walletHistoryStatus: 'idle',
   matchStake: 0,
   matchBoostStake: 0,
   addTransaction: (tx) => set((state) => ({ transactions: [tx, ...state.transactions].slice(0, 50) })),
+  setWalletHistory: (entries, summary, status) => set({
+    walletHistory: entries.slice(0, 80),
+    walletHistorySummary: summary,
+    walletHistoryStatus: status,
+  }),
 
   // Match state
   matchId: null,


### PR DESCRIPTION
Stacked on #48.

Closes #38.

## Summary

- Adds a sanitized payments-service wallet history endpoint for Telegram users that combines private payment ledger rows with paid-ELM PvP economy events.
- Updates Profile to render Wallet History with Stars purchases, ELM credits, pending/settled reverse conversions, stakes, winnings, draw refunds, and visually distinct statuses.
- Adds wallet history state to bug reports with sanitized counts/recent entries only; no bot token, init data, invoice payload, or Telegram charge ID is exposed.
- Adds refund request/success/failure logs and README SQL examples for operator ledger lookup by Telegram user ID, account ID, purchase ID, and charge ID.

## Notes

The `payment_ledger` table remains private. TMA receives only sanitized history fields from the payments service, while operator charge-ID lookup stays in SpacetimeDB SQL/debug tooling.

## Validation

- `pnpm --filter @elmental/payments test`
- `pnpm --filter @elmental/payments build`
- `pnpm --filter @elmental/tma test -- run`
- `pnpm --filter @elmental/tma build`
- Browser smoke with local TMA dev server: Telegram-like Profile loads `/payments/wallet/history` and renders purchase, credit, pending refund, PvP stake, and PvP winnings without exposing charge IDs.
